### PR TITLE
Release prep

### DIFF
--- a/Decsys/.travis.yml
+++ b/Decsys/.travis.yml
@@ -1,6 +1,0 @@
-dist: trusty
-language: csharp
-mono: none
-dotnet: 2.2
-script:
-  - dotnet publish -c release # publish builds a dotnet runtime dll and production webpack

--- a/Decsys/.travis.yml
+++ b/Decsys/.travis.yml
@@ -1,0 +1,6 @@
+dist: trusty
+language: csharp
+mono: none
+dotnet: 2.2
+script:
+  - dotnet publish -c release # publish builds a dotnet runtime dll and production webpack

--- a/Decsys/ClientApp/src/app/App.js
+++ b/Decsys/ClientApp/src/app/App.js
@@ -5,6 +5,8 @@ import { Route, Redirect, Switch, withRouter } from "react-router-dom";
 import SurveysScreen from "./screens/admin/SurveysScreen";
 import { Container, EmptyState, FlexBox } from "./components/ui";
 import { fetchSurveys } from "./state/ducks/surveys";
+import { push } from "connected-react-router";
+import { CheckCircle } from "styled-icons/fa-solid";
 
 const PureApp = ({ dispatch, listLoaded }) => {
   return (
@@ -22,10 +24,30 @@ const PureApp = ({ dispatch, listLoaded }) => {
 
         <Route
           path="/admin"
+          exact
           render={() => {
             dispatch(fetchSurveys());
             return <SurveysScreen />;
           }}
+        />
+
+        <Route
+          path="/admin/survey/:id"
+          render={() => (
+            // TODO: temporary content before editor is ready
+            <Container>
+              <FlexBox mt={5}>
+                <EmptyState
+                  splash={<CheckCircle />}
+                  message="Your Survey was created! The Editor is not ready yet."
+                  callToAction={{
+                    label: "Back to Survey List",
+                    onClick: () => dispatch(push("/admin"))
+                  }}
+                />
+              </FlexBox>
+            </Container>
+          )}
         />
 
         <Route

--- a/Decsys/ClientApp/src/app/state/ducks/surveys/ops.js
+++ b/Decsys/ClientApp/src/app/state/ducks/surveys/ops.js
@@ -12,7 +12,7 @@ export const createSurvey = () => dispatch =>
   // create the survey
   axios.post("/api/surveys").then(
     // redirect to the editor with this survey
-    response => dispatch(push(`survey/${response.data}`))
+    response => dispatch(push(`admin/survey/${response.data}`))
   );
 
 /**

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -11,10 +11,6 @@
     <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile></DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
@@ -34,6 +30,12 @@
 
   <ItemGroup>
     <Folder Include="ClientApp\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="components\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -51,8 +51,13 @@
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
+    <!-- <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" /> -->
+
+    <!-- 
+    Actually, We run the webpack build ourselves in CI,
+    so we just need the publish inclusion below
+    -->
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -9,6 +9,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Decsys/Startup.cs
+++ b/Decsys/Startup.cs
@@ -65,10 +65,13 @@ namespace Decsys
             {
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
+                // app.UseHsts(); TODO: Add HSTS when ready, or make it configurable. Only applies to hosted versions anyway.
             }
 
-            app.UseHttpsRedirection();
+            // We want to be able to turn this off for some local scenarios
+            // where getting/signing/accepting certs isn't really feasible
+            if(Configuration.GetValue<bool>("RequireHttps")) app.UseHttpsRedirection();
+
             app.UseStaticFiles();
 
             // components' static files

--- a/Decsys/appsettings.json
+++ b/Decsys/appsettings.json
@@ -8,6 +8,7 @@
   "ConnectionStrings": {
     "DocumentStore": "decsys.db"
   },
+  "RequireHttps": true,
   "Paths": {
     "Components": { "Root": "components" }
   }


### PR DESCRIPTION
Some initial release prep, ready for builds (and ultimately releases) in Azure DevOps:

- Creating Surveys goes to a dummy success page, until we have the Editor working.
- `components/` folder included in `dotnet publish`
- added support for `win-x64` self contained publish
- stopped `doetnet publish` from running webpack build as we will do that ourselves in CI to avoid repeating effort when publishing for different targets