### PR TITLE
Preview

### DIFF
--- a/Decsys/ClientApp/src/app/App.js
+++ b/Decsys/ClientApp/src/app/App.js
@@ -7,7 +7,7 @@ import { Container, EmptyState, FlexBox } from "./components/ui";
 import { fetchSurveys } from "./state/ducks/surveys";
 import { getSurvey } from "./state/ducks/editor/ops";
 import EditorScreen from "./screens/admin/EditorScreen";
-import { Grid, Cell } from "styled-css-grid";
+import PreviewScreen from "./screens/admin/PreviewScreen";
 
 const PureApp = ({ dispatch }) => {
   return (
@@ -31,25 +31,20 @@ const PureApp = ({ dispatch }) => {
       />
 
       <Route
-        path="/component-test"
-        exact
-        render={() => {
-          const Component = window.__DECSYS__.Components.FreeText;
-          return (
-            <>
-              <AppBar brand="DECSYS" />
-              <Component />
-            </>
-          );
-        }}
-      />
-
-      <Route
         path="/admin/survey/:id"
         exact
         render={({ match }) => {
           dispatch(getSurvey(match.params.id));
           return <EditorScreen id={match.params.id} />;
+        }}
+      />
+
+      <Route
+        path="/admin/survey/:id/preview"
+        exact
+        render={({ match }) => {
+          dispatch(getSurvey(match.params.id));
+          return <PreviewScreen id={match.params.id} />;
         }}
       />
 

--- a/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
@@ -1,25 +1,31 @@
-import React from "react";
+import React, { cloneElement } from "react";
 import PropTypes from "prop-types";
 import { FlexBox, Container } from "../ui";
 import Brand from "./Brand";
 import { Grid } from "styled-css-grid";
 
-const AppBar = ({ brand, children, variant }) => {
+const AppBar = ({ brand, children, variant, brandLink }) => {
   return (
     <FlexBox backgroundColor={variant} alignItems="center">
       <Container>
         <FlexBox alignItems="center" justifyContent="space-between">
-          <Brand variant={variant}>{brand}</Brand>
+          <Brand variant={variant} to={brandLink}>
+            {brand}
+          </Brand>
           {children != null && (
             <Grid
-              columns={Array(children.length)
+              columns={Array(children.length || 1)
                 .fill("auto")
                 .join(" ")}
             >
-              {children.map(x => ({
-                ...x,
-                props: { ...x.props, variant: x.props.variant || variant }
-              }))}
+              {children.length
+                ? children.map(x => ({
+                    ...x,
+                    props: { ...x.props, variant: x.props.variant || variant }
+                  }))
+                : cloneElement(children, {
+                    variant: children.props.variant || variant
+                  })}
             </Grid>
           )}
         </FlexBox>
@@ -29,6 +35,7 @@ const AppBar = ({ brand, children, variant }) => {
 };
 
 AppBar.propTypes = {
+  brandLink: PropTypes.string,
   brand: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
@@ -37,7 +44,8 @@ AppBar.propTypes = {
   variant: PropTypes.string
 };
 AppBar.defaultProps = {
-  variant: "uiPanel1"
+  variant: "uiPanel1",
+  brandLink: "/"
 };
 
 export default AppBar;

--- a/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
@@ -6,6 +6,7 @@ import { Grid } from "styled-css-grid";
 
 const AppBar = ({ brand, children, variant, brandLink }) => {
   const childContent = (() => {
+    if (!children) return;
     if (children.length) {
       return children.map(x => ({
         ...x,

--- a/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/AppBar.js
@@ -5,6 +5,19 @@ import Brand from "./Brand";
 import { Grid } from "styled-css-grid";
 
 const AppBar = ({ brand, children, variant, brandLink }) => {
+  const childContent = (() => {
+    if (children.length) {
+      return children.map(x => ({
+        ...x,
+        props: { ...x.props, variant: x.props.variant || variant }
+      }));
+    } else {
+      return cloneElement(children, {
+        variant: children.props.variant || variant
+      });
+    }
+  })();
+
   return (
     <FlexBox backgroundColor={variant} alignItems="center">
       <Container>
@@ -18,14 +31,7 @@ const AppBar = ({ brand, children, variant, brandLink }) => {
                 .fill("auto")
                 .join(" ")}
             >
-              {children.length
-                ? children.map(x => ({
-                    ...x,
-                    props: { ...x.props, variant: x.props.variant || variant }
-                  }))
-                : cloneElement(children, {
-                    variant: children.props.variant || variant
-                  })}
+              {childContent}
             </Grid>
           )}
         </FlexBox>

--- a/Decsys/ClientApp/src/app/components/AppBar/AppBar.stories.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/AppBar.stories.js
@@ -10,6 +10,11 @@ storiesOf("AppBar", module)
   .addDecorator(StoryRouter())
   .add("Default", () => <AppBar />)
   .add("Brand", () => <AppBar variant="danger" brand="My Brand" />)
+  .add("One Child", () => (
+    <AppBar>
+      <AppBarLink to="/somewhere">Clicky time</AppBarLink>
+    </AppBar>
+  ))
   .add("Children", () => (
     <AppBar variant="#ffdddd">
       <AppBarLink to="/link">A link</AppBarLink>

--- a/Decsys/ClientApp/src/app/components/AppBar/Brand.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/Brand.js
@@ -6,7 +6,7 @@ const Brand = styled(Link).attrs(() => ({
   variant: "h4",
   display: "inline",
   mb: ".1rem",
-  to: "/"
+  to: `${({ to }) => to || "/"}`
 }))``;
 
 Brand.propTypes = {

--- a/Decsys/ClientApp/src/app/components/AppBar/Brand.stories.js
+++ b/Decsys/ClientApp/src/app/components/AppBar/Brand.stories.js
@@ -6,4 +6,9 @@ import Brand from "./Brand";
 storiesOf("AppBar/Brand", module)
   .addDecorator(StoryRouter())
   .add("Dark background", () => <Brand variant="dark">Hello</Brand>)
-  .add("Light background", () => <Brand variant="light">Hello</Brand>);
+  .add("Light background", () => <Brand variant="light">Hello</Brand>)
+  .add("Alternative link", () => (
+    <Brand to="/somewhere/else" variant="light">
+      Hello
+    </Brand>
+  ));

--- a/Decsys/ClientApp/src/app/components/ComponentEditor/ComponentEditor.js
+++ b/Decsys/ClientApp/src/app/components/ComponentEditor/ComponentEditor.js
@@ -4,6 +4,8 @@ import { Grid } from "styled-css-grid";
 import { Typography } from "@smooth-ui/core-sc";
 
 const ComponentEditor = ({ component, params, onChange }) => {
+  if (!component) return null;
+
   const list = [];
   for (const key in component.params) {
     const p = component.params[key];
@@ -24,7 +26,7 @@ const ComponentEditor = ({ component, params, onChange }) => {
   }
 
   return (
-    <Grid columns="1fr 5fr" rowGap=".2em">
+    <Grid columns="2fr 5fr" rowGap=".2em">
       {list}
     </Grid>
   );

--- a/Decsys/ClientApp/src/app/components/ComponentEditor/ImageUpload.js
+++ b/Decsys/ClientApp/src/app/components/ComponentEditor/ImageUpload.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Button, Input, Box } from "@smooth-ui/core-sc";
-import { FlexBox } from "../ui";
 
 const ImageUpload = ({ params, onAddClick, onRemoveClick }) => {
   const hasImage = !!params.extension;

--- a/Decsys/ClientApp/src/app/components/ComponentEditor/Param.js
+++ b/Decsys/ClientApp/src/app/components/ComponentEditor/Param.js
@@ -74,6 +74,8 @@ const Param = ({ paramKey, value, type, oneOf, onChange }) => {
             onChange={delayedHandleValueChange}
           />
         );
+      default:
+        throw new Error("Unknown Parameter type");
     }
   })(type);
 

--- a/Decsys/ClientApp/src/app/components/ComponentEditor/Param.stories.js
+++ b/Decsys/ClientApp/src/app/components/ComponentEditor/Param.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import Param from "./Param";
-import { types } from "../../../param-types";
+import { types } from "@decsys/param-types";
 import { text, boolean, optionsKnob } from "@storybook/addon-knobs";
 
 const oneOf = ["Hello", "Goodbye", "Something else"];

--- a/Decsys/ClientApp/src/app/components/ComponentRender/ComponentRender.js
+++ b/Decsys/ClientApp/src/app/components/ComponentRender/ComponentRender.js
@@ -1,6 +1,6 @@
 import React, { cloneElement } from "react";
 
-const ComponentRender = ({ component, actions, params }) => {
+const ComponentRender = ({ component, params, actions }) => {
   // short circuit
   if (!component) return null;
 

--- a/Decsys/ClientApp/src/app/components/ComponentRender/ComponentRender.js
+++ b/Decsys/ClientApp/src/app/components/ComponentRender/ComponentRender.js
@@ -1,6 +1,6 @@
 import React, { cloneElement } from "react";
 
-const ComponentRender = ({ component, params }) => {
+const ComponentRender = ({ component, actions, params }) => {
   // short circuit
   if (!component) return null;
 
@@ -13,7 +13,7 @@ const ComponentRender = ({ component, params }) => {
     return agg;
   }, {});
 
-  return cloneElement(<Component />, { ...defaults, ...params });
+  return cloneElement(<Component />, { ...defaults, ...params, ...actions });
 };
 
 export default ComponentRender;

--- a/Decsys/ClientApp/src/app/components/EditorBar/EditorBar.js
+++ b/Decsys/ClientApp/src/app/components/EditorBar/EditorBar.js
@@ -7,7 +7,7 @@ import {
   Trash,
   ChevronLeft
 } from "styled-icons/fa-solid";
-import { Grid, Cell } from "styled-css-grid";
+import { Grid } from "styled-css-grid";
 import EditorBarButton, { LinkButton as EditorBarLink } from "./Button";
 import NameInput from "./NameInput";
 import DeleteSurveyModal from "../SurveyCard/DeleteSurveyModal";

--- a/Decsys/ClientApp/src/app/components/EditorPageList/EditorPageList.js
+++ b/Decsys/ClientApp/src/app/components/EditorPageList/EditorPageList.js
@@ -30,13 +30,18 @@ const EditorPageList = ({ actions, components, pages, component }) => {
             style={{ overflow: "auto", minHeight: "100%F" }}
           >
             <FlexBox flexDirection="column" px={2}>
-              <FlexBox justifyContent="space-between" alignItems="center">
-                <Typography textAlign="center" p={1}>
+              <FlexBox
+                justifyContent="space-between"
+                alignItems="center"
+                py={1}
+              >
+                <Typography p={1} variant="h4" mb={0.1}>
                   Survey Pages
                 </Typography>
                 <Button
-                  size="sm"
                   variant="success"
+                  border={1}
+                  borderColor="uiPanel1"
                   onClick={actions.onAddClick}
                 >
                   <Plus size="1em" /> Add Page

--- a/Decsys/ClientApp/src/app/components/EditorPageList/EditorPageList.js
+++ b/Decsys/ClientApp/src/app/components/EditorPageList/EditorPageList.js
@@ -38,12 +38,7 @@ const EditorPageList = ({ actions, components, pages, component }) => {
                 <Typography p={1} variant="h4" mb={0.1}>
                   Survey Pages
                 </Typography>
-                <Button
-                  variant="success"
-                  border={1}
-                  borderColor="uiPanel1"
-                  onClick={actions.onAddClick}
-                >
+                <Button variant="success" onClick={actions.onAddClick}>
                   <Plus size="1em" /> Add Page
                 </Button>
               </FlexBox>

--- a/Decsys/ClientApp/src/app/components/EditorPageList/Page.js
+++ b/Decsys/ClientApp/src/app/components/EditorPageList/Page.js
@@ -5,7 +5,6 @@ import PageHeader from "./PageHeader";
 import PageComponent from "./PageComponent";
 import PageItem from "./PageItem";
 import { Droppable, Draggable } from "react-beautiful-dnd";
-import { setCurrentComponent } from "../../state/ducks/editor";
 
 const Page = ({
   page,
@@ -26,7 +25,7 @@ const Page = ({
             flexDirection="column"
             border={1}
             borderColor="cardBorder"
-            backgroundColor="cardBg"
+            backgroundColor="lightest"
           >
             <PageHeader
               provided={pageListProvided}

--- a/Decsys/ClientApp/src/app/components/EditorPageList/PageHeader.js
+++ b/Decsys/ClientApp/src/app/components/EditorPageList/PageHeader.js
@@ -23,7 +23,7 @@ const PageHeader = ({
   }
 }) => {
   return (
-    <Box pr={1} border="red" borderBottom={1}>
+    <Box pr={1} borderBottom={1} borderColor="cardBorder">
       <Grid columns="30px 1fr 70px 30px 30px 30px 30px 30px" columnGap=".1em">
         <Cell middle>
           <div {...provided.dragHandleProps}>
@@ -47,7 +47,11 @@ const PageHeader = ({
         <Cell middle>
           <Button
             size="sm"
-            variant="success"
+            variant="light"
+            color="success"
+            border={1}
+            borderColor="success"
+            backgroundColor="lightest"
             onClick={() => onAddPageItemClick(id, "heading")}
             title="Add a Heading to this Page"
           >
@@ -57,7 +61,11 @@ const PageHeader = ({
         <Cell middle>
           <Button
             size="sm"
-            variant="success"
+            variant="light"
+            color="success"
+            border={1}
+            borderColor="success"
+            backgroundColor="lightest"
             onClick={() => onAddPageItemClick(id, "paragraph")}
             title="Add a Paragraph to this Page"
           >
@@ -67,7 +75,11 @@ const PageHeader = ({
         <Cell middle>
           <Button
             size="sm"
-            variant="success"
+            variant="light"
+            color="success"
+            border={1}
+            borderColor="success"
+            backgroundColor="lightest"
             onClick={() => onAddPageItemClick(id, "image")}
             title="Add an Image to this Page"
           >
@@ -79,6 +91,8 @@ const PageHeader = ({
           <Button
             size="sm"
             variant="light"
+            backgroundColor="lightest"
+            color="info"
             onClick={() => onDuplicateClick(id)}
             title="Duplicate this Page"
           >
@@ -88,7 +102,9 @@ const PageHeader = ({
         <Cell middle>
           <Button
             size="sm"
-            variant="danger"
+            variant="light"
+            color="danger"
+            backgroundColor="lightest"
             onClick={() => onDeleteClick(id)}
             title="Delete this Page"
           >

--- a/Decsys/ClientApp/src/app/components/EditorPageList/PageItem.js
+++ b/Decsys/ClientApp/src/app/components/EditorPageList/PageItem.js
@@ -77,7 +77,8 @@ const PageItem = ({
         </Button>
         <Button
           size="sm"
-          variant="danger"
+          variant="light"
+          color="danger"
           onClick={() => onDeleteClick(pageId, id)}
         >
           <Times size="1em" />

--- a/Decsys/ClientApp/src/app/screens/admin/EditorScreen.js
+++ b/Decsys/ClientApp/src/app/screens/admin/EditorScreen.js
@@ -8,14 +8,12 @@ import EditorPageList from "../../components/EditorPageList";
 import { LoadingIndicator, FlexBox, EmptyState } from "../../components/ui";
 import * as ducks from "../../state/ducks/editor";
 import { FileAlt } from "styled-icons/fa-solid";
-import { Box } from "@smooth-ui/core-sc";
+import { Box, colorVariant } from "@smooth-ui/core-sc";
 import ComponentRender from "../../components/ComponentRender";
 import ComponentEditor from "../../components/ComponentEditor";
-import PageHeading from "../../components/page-items/Heading";
-import PageParagraph from "../../components/page-items/Paragraph";
-import PageImage from "../../components/page-items/Image";
 import ParagraphPreview from "../../components/ComponentEditor/ParagraphPreview";
 import ImageUpload from "../../components/ComponentEditor/ImageUpload";
+import { getComponent } from "../../utils/component-utils";
 
 const PureEditorScreen = ({
   id,
@@ -45,21 +43,9 @@ const PureEditorScreen = ({
     />
   );
 
-  // try and get the current component from those available
-  let CurrentComponent;
-  if (component) {
-    // check for built-in Page Item types
-    const builtIn = {
-      heading: PageHeading,
-      paragraph: PageParagraph,
-      image: PageImage
-    };
-    if (Object.keys(builtIn).includes(component.component.type)) {
-      CurrentComponent = builtIn[component.component.type];
-    } else {
-      CurrentComponent = window.__DECSYS__.Components[component.component.type];
-    }
-  }
+  const CurrentComponent = component
+    ? getComponent(component.component.type)
+    : null;
 
   return !surveyLoaded ? (
     <FlexBox flexDirection="column">
@@ -69,7 +55,7 @@ const PureEditorScreen = ({
   ) : (
     <Grid
       columns="1fr 2fr"
-      rows="50px minmax(200px, 2fr) minmax(200px, 1fr)"
+      rows="auto minmax(200px, 2fr) minmax(200px, 1fr)"
       rowGap="0px"
       height="100%"
       columnGap="0px"
@@ -82,7 +68,7 @@ const PureEditorScreen = ({
         height={2}
         style={{
           overflow: "auto",
-          background: "gray300" // TODO:
+          backgroundColor: colorVariant("gray500")({})
         }}
       >
         <EditorPageList
@@ -124,7 +110,13 @@ const PureEditorScreen = ({
               />
             )}
           </Cell>
-          <Cell style={{ padding: "1em", overflow: "auto" }}>
+          <Cell
+            style={{
+              padding: "1em",
+              overflow: "auto",
+              backgroundColor: colorVariant("gray300")({})
+            }}
+          >
             {component.component.type === "image" ? (
               <ImageUpload
                 params={component.component.params}

--- a/Decsys/ClientApp/src/app/screens/admin/PreviewScreen.js
+++ b/Decsys/ClientApp/src/app/screens/admin/PreviewScreen.js
@@ -1,6 +1,38 @@
-import React from "react";
-import { Container } from "../../components/ui";
+import React, { useState } from "react";
+import { withRouter } from "react-router-dom";
+import { connect } from "react-redux";
+import { PureSurveyScreen } from "../survey/SurveyScreen";
+import { LoadingIndicator } from "../../components/ui";
 
-const PreviewScreen = () => <Container>Preview</Container>;
+const PurePreviewScreen = ({ id, survey, surveyLoaded, history }) => {
+  const [page, setPage] = useState(0);
+
+  const handleClick = () => {
+    if (page === survey.pages.length - 1) history.push(`/admin/survey/${id}`);
+    setPage(page + 1);
+  };
+
+  return surveyLoaded ? (
+    <PureSurveyScreen
+      id={id}
+      nPage={page}
+      page={survey.pages[page]}
+      preview
+      onClick={handleClick}
+      pageCount={survey.pages.length}
+    />
+  ) : (
+    <LoadingIndicator />
+  );
+};
+
+const PreviewScreen = withRouter(
+  connect(({ editor: { survey, surveyLoaded } }) => ({
+    survey,
+    surveyLoaded
+  }))(PurePreviewScreen)
+);
+
+export { PurePreviewScreen };
 
 export default PreviewScreen;

--- a/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.js
+++ b/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.js
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import { Grid, Cell } from "styled-css-grid";
+import AppBar from "../../components/AppBar";
+import { FlexBox, Container } from "../../components/ui";
+import { Button } from "@smooth-ui/core-sc";
+import { ChevronRight } from "styled-icons/fa-solid";
+import ComponentRender from "../../components/ComponentRender";
+import { getComponent } from "../../utils/component-utils";
+
+const SurveyScreen = ({ id, components, page }) => {
+  const [nextEnabled, setNextEnabled] = useState(true);
+
+  return (
+    <Grid columns="1fr" style={{ height: "100vh" }}>
+      <Cell>
+        <AppBar brand="DECSYS" />
+      </Cell>
+      <Cell style={{ overflow: "auto" }}>
+        <Container>
+          <FlexBox p={1} flexDirection="column">
+            {page.components.map(x => (
+              <ComponentRender
+                key={x.id}
+                component={getComponent(x.type)}
+                actions={{ setNextEnabled }}
+                params={
+                  x.type === "image"
+                    ? {
+                        ...x.params,
+                        surveyId: id,
+                        id: x.id
+                      }
+                    : x.params
+                }
+              />
+            ))}
+          </FlexBox>
+        </Container>
+      </Cell>
+      <Cell>
+        <Container>
+          <FlexBox p={2} justifyContent="flex-end">
+            <Button size="lg" disabled={!nextEnabled}>
+              Next <ChevronRight size="1em" />
+            </Button>
+          </FlexBox>
+        </Container>
+      </Cell>
+    </Grid>
+  );
+};
+
+export default SurveyScreen;

--- a/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.js
+++ b/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.js
@@ -6,14 +6,21 @@ import { Button } from "@smooth-ui/core-sc";
 import { ChevronRight } from "styled-icons/fa-solid";
 import ComponentRender from "../../components/ComponentRender";
 import { getComponent } from "../../utils/component-utils";
+import Link from "../../components/AppBar/Link";
 
-const SurveyScreen = ({ id, components, page }) => {
+const PureSurveyScreen = ({ id, page, preview, onClick, pageCount, nPage }) => {
   const [nextEnabled, setNextEnabled] = useState(true);
 
   return (
     <Grid columns="1fr" style={{ height: "100vh" }}>
       <Cell>
-        <AppBar brand="DECSYS" />
+        {preview ? (
+          <AppBar brand="DECSYS - Preview" brandLink="#">
+            <Link to={`/admin/survey/${id}`}>Back to Survey Editor</Link>
+          </AppBar>
+        ) : (
+          <AppBar brand="DECSYS" />
+        )}
       </Cell>
       <Cell style={{ overflow: "auto" }}>
         <Container>
@@ -40,8 +47,14 @@ const SurveyScreen = ({ id, components, page }) => {
       <Cell>
         <Container>
           <FlexBox p={2} justifyContent="flex-end">
-            <Button size="lg" disabled={!nextEnabled}>
-              Next <ChevronRight size="1em" />
+            <Button size="lg" disabled={!nextEnabled} onClick={onClick}>
+              {nPage === pageCount - 1 ? (
+                <>Finish</>
+              ) : (
+                <>
+                  Next <ChevronRight size="1em" />
+                </>
+              )}
             </Button>
           </FlexBox>
         </Container>
@@ -50,4 +63,6 @@ const SurveyScreen = ({ id, components, page }) => {
   );
 };
 
-export default SurveyScreen;
+export { PureSurveyScreen };
+
+//export default SurveyScreen;

--- a/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.stories.js
+++ b/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import StoryRouter from "storybook-react-router";
-import SurveyScreen from "./SurveyScreen";
+import { PureSurveyScreen } from "./SurveyScreen";
 
 const page = {
   id: 1,
@@ -27,4 +27,4 @@ const page = {
 
 storiesOf("SurveyScreen", module)
   .addDecorator(StoryRouter())
-  .add("Default", () => <SurveyScreen page={page} />);
+  .add("Default", () => <PureSurveyScreen page={page} />);

--- a/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.stories.js
+++ b/Decsys/ClientApp/src/app/screens/survey/SurveyScreen.stories.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import StoryRouter from "storybook-react-router";
+import SurveyScreen from "./SurveyScreen";
+
+const page = {
+  id: 1,
+  components: [
+    {
+      id: 1,
+      type: "heading",
+      params: {
+        text: "Hello there"
+      }
+    },
+    {
+      id: 1,
+      type: "paragraph",
+      params: {
+        text: `Let's have some information text here for you to read...
+        
+![](https://cataas.com/cat)`
+      }
+    }
+  ]
+};
+
+storiesOf("SurveyScreen", module)
+  .addDecorator(StoryRouter())
+  .add("Default", () => <SurveyScreen page={page} />);

--- a/Decsys/ClientApp/src/app/themes/index.js
+++ b/Decsys/ClientApp/src/app/themes/index.js
@@ -15,6 +15,8 @@ export default {
   cardBorder: th("gray400"),
   menuBg: th("light"),
   menuItem: th("light"),
+  lightest: th("white"), //swap light and dark for dark themes... so it's relatively inverted?
+  darkest: "#111",
 
   // also need to add new colors here for variants to work
   colors: {
@@ -26,6 +28,8 @@ export default {
     cardHoverBg: th("cardHoverBg"),
     cardBorder: th("cardBorder"),
     menuBg: th("menuBg"),
-    menuItem: th("menuItem")
+    menuItem: th("menuItem"),
+    lightest: th("lightest"),
+    darkest: th("darkest")
   }
 };

--- a/Decsys/ClientApp/src/app/utils/component-utils.js
+++ b/Decsys/ClientApp/src/app/utils/component-utils.js
@@ -1,0 +1,14 @@
+import PageHeading from "../components/page-items/Heading";
+import PageParagraph from "../components/page-items/Paragraph";
+import PageImage from "../components/page-items/Image";
+
+export const builtInLookup = type => ({
+  heading: PageHeading,
+  paragraph: PageParagraph,
+  image: PageImage
+});
+
+export const isBuiltIn = type => Object.keys(builtInLookup).includes(type);
+
+export const getComponent = type =>
+  isBuiltIn(type) ? builtInLookup[type] : window.__DECSYS__.Components[type];

--- a/Decsys/ClientApp/src/app/utils/component-utils.js
+++ b/Decsys/ClientApp/src/app/utils/component-utils.js
@@ -2,11 +2,11 @@ import PageHeading from "../components/page-items/Heading";
 import PageParagraph from "../components/page-items/Paragraph";
 import PageImage from "../components/page-items/Image";
 
-export const builtInLookup = type => ({
+export const builtInLookup = {
   heading: PageHeading,
   paragraph: PageParagraph,
   image: PageImage
-});
+};
 
 export const isBuiltIn = type => Object.keys(builtInLookup).includes(type);
 

--- a/Decsys/ClientApp/src/index.js
+++ b/Decsys/ClientApp/src/index.js
@@ -1,6 +1,6 @@
 import * as serviceWorker from "./serviceWorker";
 import React from "react";
-import styled, { css, createGlobalStyle } from "styled-components";
+import styled, { css } from "styled-components";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { createBrowserHistory } from "history";
@@ -23,6 +23,7 @@ window.__DECSYS__ = {}; // Register our global namespace at bootstrap time
 window.React = React;
 window.ReactDOM = ReactDOM;
 window.PropTypes = PropTypes;
+// TODO: we should put param-types here - all DECSYS components will use it, save them all bundling it
 
 // Styled doesn't put all its named exports on the default :(
 // So I guess that job is on us until we have a better way to do this than globals


### PR DESCRIPTION
Admin Survey Preview works.

- Added a Screen for presenting Surveys. This will turn into a connected Component for participants later
- Added a Screen for admins to preview Surveys. This uses the pure Surveys Screen above, so that is reused.
- Added route for the Preview Screen, so the links work.
- AppBar gained some features for PreviewScreen use:
  - Brand doesn't have to only link to "/"
  - Single links in AppBar were broken; they're fixed now.
- Fixed CRA Webpack's outstanding warnings