### PR TITLE
Participant usage improvements

### DIFF
--- a/Decsys/ClientApp/package-lock.json
+++ b/Decsys/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -992,9 +992,9 @@
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@decsys/param-types": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@decsys/param-types/-/param-types-0.2.0.tgz",
-      "integrity": "sha512-tQbhg9lwTvyplsJPDfeEg6tG2fAN/PQheE+xbsRuYZi4649rgYOwGI09ND6XT3JSR69bWy64TI+q7JbJ40vFZA=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@decsys/param-types/-/param-types-0.3.1.tgz",
+      "integrity": "sha512-3g5qatf3gsEiKpTow8KrI5uwRTQCZ7Fb68ZeMnEn1MOmRtDCvssetBbyahlWAjd5V+FeEiQpqhzLki3rYGeMGg=="
     },
     "@emotion/babel-utils": {
       "version": "0.6.10",

--- a/Decsys/ClientApp/package.json
+++ b/Decsys/ClientApp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "client-app",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "dependencies": {
-    "@decsys/param-types": "^0.2.0",
+    "@decsys/param-types": "^0.3.1",
     "@smooth-ui/core-sc": "^9.1.0",
     "axios": "^0.18.0",
     "gfycat-style-urls": "^1.0.3",
@@ -51,7 +51,6 @@
     "@storybook/addon-links": "^5.0.6",
     "@storybook/addons": "^5.0.6",
     "@storybook/react": "^5.0.10",
-    "babel-loader": "^8.0.5",
     "husky": "^1.3.1",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",

--- a/Decsys/ClientApp/src/app/components/page-items/Heading.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Heading.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Typography } from "@smooth-ui/core-sc";
-import paramTypes, { setParams } from "@decsys/param-types";
+import ParamTypes, { buildPropTypes } from "@decsys/param-types";
 
 const PageHeading = ({ text, xMargin, ...p }) => (
   <Typography
@@ -13,21 +13,24 @@ const PageHeading = ({ text, xMargin, ...p }) => (
   </Typography>
 );
 
-setParams(PageHeading, {
-  text: paramTypes.string("Text"),
-  variant: paramTypes.oneOf(
+PageHeading.params = {
+  text: ParamTypes.string("Text"),
+  variant: ParamTypes.oneOf(
     "Heading Style",
     ["h1", "h2", "h3", "h4", "h5"],
     "h2"
   ),
-  color: paramTypes.string("Color", "black"),
-  textAlign: paramTypes.oneOf(
+  color: ParamTypes.string("Color", "black"),
+  textAlign: ParamTypes.oneOf(
     "Alignment",
     ["left", "center", "right"],
     "center"
   ),
-  xMargin: paramTypes.number("Horizontal Margin", 5),
-  fontFamily: paramTypes.stringUndefined("Font Family")
-});
+  xMargin: ParamTypes.number("Horizontal Margin", 5),
+  fontFamily: ParamTypes.stringUndefined("Font Family")
+};
+const { pt, defaultProps } = buildPropTypes(PageHeading.params);
+PageHeading.propTypes = pt;
+PageHeading.defaultProps = defaultProps;
 
 export default PageHeading;

--- a/Decsys/ClientApp/src/app/components/page-items/Image.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Image.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import paramTypes, { setParams } from "@decsys/param-types";
+import paramTypes, { buildPropTypes } from "@decsys/param-types";
 import { FlexBox } from "../ui";
 
 const PageImage = ({ surveyId, id, extension }) => {
@@ -33,13 +33,15 @@ const PageImage = ({ surveyId, id, extension }) => {
   );
 };
 
-PageImage.propTypes = {
-  surveyId: PropTypes.number,
-  id: PropTypes.string
+PageImage.params = {
+  extension: paramTypes.stringUndefined("Image File Extension")
 };
 
-setParams(PageImage, {
-  extension: paramTypes.stringUndefined("Image File Extension")
+const { pt, defaultProps } = buildPropTypes(PageImage.params, {
+  surveyId: PropTypes.number,
+  id: PropTypes.string
 });
+PageImage.propTypes = pt;
+PageImage.defaultProps = defaultProps;
 
 export default PageImage;

--- a/Decsys/ClientApp/src/app/components/page-items/Image.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Image.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import paramTypes, { buildPropTypes } from "@decsys/param-types";
+import ParamTypes, { buildPropTypes } from "@decsys/param-types";
 import { FlexBox } from "../ui";
 
 const PageImage = ({ surveyId, id, extension }) => {
@@ -34,7 +34,7 @@ const PageImage = ({ surveyId, id, extension }) => {
 };
 
 PageImage.params = {
-  extension: paramTypes.stringUndefined("Image File Extension")
+  extension: ParamTypes.stringUndefined("Image File Extension")
 };
 
 const { pt, defaultProps } = buildPropTypes(PageImage.params, {

--- a/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Typography } from "@smooth-ui/core-sc";
-import paramTypes, { setParams } from "@decsys/param-types";
+import paramTypes, { buildPropTypes } from "@decsys/param-types";
 import ReactMarkdown from "react-markdown";
 
 const PageParagraph = ({ text, ...p }) => (
@@ -10,14 +10,16 @@ const PageParagraph = ({ text, ...p }) => (
   </Typography>
 );
 
-PageParagraph.propTypes = {
-  text: PropTypes.string
-};
-
-setParams(PageParagraph, {
+PageParagraph.params = {
   color: paramTypes.string("Color", "black"),
   textAlign: paramTypes.oneOf("Alignment", ["left", "center", "right"], "left"),
   fontFamily: paramTypes.stringUndefined("Font Family")
+};
+
+const { pt, defaultProps } = buildPropTypes(PageParagraph.params, {
+  text: PropTypes.string
 });
+PageParagraph.propTypes = pt;
+PageParagraph.defaultProps = defaultProps;
 
 export default PageParagraph;

--- a/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Typography } from "@smooth-ui/core-sc";
 import ParamTypes, { buildPropTypes } from "@decsys/param-types";
 import ReactMarkdown from "react-markdown";
@@ -10,13 +11,14 @@ const PageParagraph = ({ text, ...p }) => (
 );
 
 PageParagraph.params = {
-  text: ParamTypes.string("Text"),
   color: ParamTypes.string("Color", "black"),
   textAlign: ParamTypes.oneOf("Alignment", ["left", "center", "right"], "left"),
   fontFamily: ParamTypes.stringUndefined("Font Family")
 };
 
-const { pt, defaultProps } = buildPropTypes(PageParagraph.params);
+const { pt, defaultProps } = buildPropTypes(PageParagraph.params, {
+  text: PropTypes.string
+});
 PageParagraph.propTypes = pt;
 PageParagraph.defaultProps = defaultProps;
 

--- a/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Paragraph.js
@@ -1,7 +1,6 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Typography } from "@smooth-ui/core-sc";
-import paramTypes, { buildPropTypes } from "@decsys/param-types";
+import ParamTypes, { buildPropTypes } from "@decsys/param-types";
 import ReactMarkdown from "react-markdown";
 
 const PageParagraph = ({ text, ...p }) => (
@@ -11,14 +10,13 @@ const PageParagraph = ({ text, ...p }) => (
 );
 
 PageParagraph.params = {
-  color: paramTypes.string("Color", "black"),
-  textAlign: paramTypes.oneOf("Alignment", ["left", "center", "right"], "left"),
-  fontFamily: paramTypes.stringUndefined("Font Family")
+  text: ParamTypes.string("Text"),
+  color: ParamTypes.string("Color", "black"),
+  textAlign: ParamTypes.oneOf("Alignment", ["left", "center", "right"], "left"),
+  fontFamily: ParamTypes.stringUndefined("Font Family")
 };
 
-const { pt, defaultProps } = buildPropTypes(PageParagraph.params, {
-  text: PropTypes.string
-});
+const { pt, defaultProps } = buildPropTypes(PageParagraph.params);
 PageParagraph.propTypes = pt;
 PageParagraph.defaultProps = defaultProps;
 

--- a/Decsys/ClientApp/src/app/components/page-items/Paragraph.stories.js
+++ b/Decsys/ClientApp/src/app/components/page-items/Paragraph.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { text, number, optionsKnob } from "@storybook/addon-knobs";
+import { text, optionsKnob } from "@storybook/addon-knobs";
 import Paragraph from "./Paragraph";
 
 const getLabel = param => Paragraph.params[param].label;

--- a/Decsys/ClientApp/src/global-init.js
+++ b/Decsys/ClientApp/src/global-init.js
@@ -42,6 +42,5 @@ export const loadComponentsModule = () => {
   const script = document.createElement("script");
   script.src = "/api/components";
   script.type = "module";
-  script.async = true;
   document.body.appendChild(script);
 };

--- a/Decsys/ClientApp/src/global-init.js
+++ b/Decsys/ClientApp/src/global-init.js
@@ -42,5 +42,6 @@ export const loadComponentsModule = () => {
   const script = document.createElement("script");
   script.src = "/api/components";
   script.type = "module";
+  script.async = true;
   document.body.appendChild(script);
 };

--- a/Decsys/Controllers/ComponentsController.cs
+++ b/Decsys/Controllers/ComponentsController.cs
@@ -82,7 +82,7 @@ namespace Decsys.Controllers
                     .AppendLine(";");
             }
 
-            output.Append("document.dispatchEvent(new Event('__DECSYS__ComponentsLoaded'));");
+            output.AppendLine("document.dispatchEvent(new Event('__DECSYS__ComponentsLoaded'));");
 
             return File(Encoding.UTF8.GetBytes(output.ToString()), "application/javascript");
         }

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -11,8 +11,6 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
-    <LangVersion>preview</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha.4</Version>
+    <Version>1.0.0-alpha.5</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Decsys/Mapping/SurveyMaps.cs
+++ b/Decsys/Mapping/SurveyMaps.cs
@@ -57,7 +57,7 @@ namespace Decsys.Mapping
                     new SurveyInstance(new Survey("")));
         }
 
-        private int? MapActiveInstanceToId(Data.Entities.SurveyInstance? instance)
+        private int? MapActiveInstanceToId(Data.Entities.SurveyInstance instance) // TODO: nullable
             => instance?.Id; // Necessary because Expression Trees are limited
     }
 }

--- a/Decsys/Pages/Error.cshtml.cs
+++ b/Decsys/Pages/Error.cshtml.cs
@@ -7,7 +7,8 @@ namespace Decsys.Pages
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
-        public string? RequestId { get; set; }
+        // TODO: nullable
+        public string RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/Decsys/Services/SurveyService.cs
+++ b/Decsys/Services/SurveyService.cs
@@ -56,7 +56,7 @@ namespace Decsys.Services
         /// </summary>
         /// <param name="name">The name to give the new Survey.</param>
         /// <returns>The ID of the newly created Survey.</returns>
-        public int Create(string? name = null)
+        public int Create(string name = null) // TODO: nullable
         {
             return _db.GetCollection<Survey>(Collections.Surveys)
                   .Insert(name is null

--- a/README.md
+++ b/README.md
@@ -4,6 +4,47 @@ The DECSYS Survey Platform aims to be a flexible cross-platform web-based survey
 
 It is used to showcase the DECSYS Ellipse Rating Scale.
 
+# Getting Started
+
+## Running the Survey Platform
+
+- For Windows 7+ (64-bit)
+  1. Download a `win-x64` asset from **Releases**
+  1. Extract it to a folder
+  1. Double-click `Run Decsys`
+  1. Open a web browser and navigate to `localhost`
+- For other OSes
+  1. Have the .NET Core runtime for your OS. (version `2.2` or newer)
+  1. Download a `dotnet-2.2` asset from **Releases**
+  1. Extract it to a folder
+  1. Run the application as follows:
+     - Use the provided `run-decsys` or `Run Decsys (Windows)` script
+     - Use the `dotnet` CLI
+       - Navigate inside the `Decsys/` folder
+       - run `dotnet decsys.dll`
+       - Optionally pass server urls argument to specify a port, otherwise `5000` will be used.
+         - e.g. `dotnet decsys.dll --server.urls http://0.0.0.0:80`
+  1. Open a web browser and navigate to `localhost`
+
+### Troubleshooting
+
+- Mostly just ensure nothing else is bound to port `80` on your network interfaces.
+  - Or edit the launch script to change the port / specify a port when using the `dotnet` CLI
+
+## Building the Survey Platform
+
+1. Meet the prerequisites:
+   - `dotnet` SDK `2.2` or newer
+     - either independently or part of Visual Studio 2017 or newer
+   - node.js `10.x` or newer (including `npm`)
+   - Optionally get some [Response Components](https://github.com/search?q=org%3Adecsys+component+in%3Aname+archived%3Afalse) and put them in `Decsys/components/`
+1. Clone this repository
+1. Inside `Decsys/ClientApp/`
+   - run `npm i`
+1. Inside `Decsys/`
+   - Open `Decsys.sln` in Visual Studio
+   - `dotnet build`
+
 # Licensing
 
 At this time, this software has no license, and therefore all rights are reserved as per author copyright, with the exception of rights waived under the GitHub Terms of Service.

--- a/scripts/Run Decsys (dotnet).bat
+++ b/scripts/Run Decsys (dotnet).bat
@@ -1,2 +1,2 @@
 cd Decsys
-dotnet decsys.dll --server.urls http://localhost:80
+dotnet decsys.dll --server.urls http://0.0.0.0:80

--- a/scripts/Run Decsys (win-x64).bat
+++ b/scripts/Run Decsys (win-x64).bat
@@ -1,2 +1,2 @@
 cd decsys
-decsys.exe --server.urls http://localhost:80
+decsys.exe --server.urls http://0.0.0.0:80

--- a/scripts/run-decsys-dotnet.sh
+++ b/scripts/run-decsys-dotnet.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 cd Decsys
-dotnet decsys.dll --server.urls http://localhost:80
+dotnet decsys.dll --server.urls http://0.0.0.0:80


### PR DESCRIPTION
- Updated `param-types` for consistency with first party Response Components.
- Updated internal Page Components for new `param-types`
- Updated launch scripts to bind on all interfaces by default instead of `localhost`
- I guess I lost a bet that C# 8 would release before the Platform hit 1.0
    - Non-nullable types / C# 8 usage have been reverted, with `TODO:`s to reinstate in future.
    - This will mean we're not shipping on preview compiler code, and will make CI easier.
- version bumps