### PR TITLE
Results Summary Csv Export

### DIFF
--- a/Decsys/ClientApp/package-lock.json
+++ b/Decsys/ClientApp/package-lock.json
@@ -12542,6 +12542,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json2csv": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-4.5.1.tgz",
+      "integrity": "sha512-o90Xa1ziGk3i7AJEO79Jac4+7SEUk58/DxS5mDPW6GF7poX0y7Y0pm1FbWrkz9VzKE4MpUW9aKBOCpJ0U1Ua8A==",
+      "requires": {
+        "commander": "^2.15.1",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
@@ -12567,6 +12577,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/Decsys/ClientApp/package.json
+++ b/Decsys/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "dependencies": {
     "@decsys/param-types": "^0.3.1",

--- a/Decsys/ClientApp/package.json
+++ b/Decsys/ClientApp/package.json
@@ -8,6 +8,7 @@
     "axios": "^0.18.0",
     "downloadjs": "^1.4.7",
     "gfycat-style-urls": "^1.0.3",
+    "json2csv": "^4.5.1",
     "navi": "^0.12.4",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha.13</Version>
+    <Version>1.0.0-alpha.14</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Decsys/Mapping/JObjectBsonConverter.cs
+++ b/Decsys/Mapping/JObjectBsonConverter.cs
@@ -10,13 +10,12 @@ namespace Decsys.Mapping
     {
         public BsonDocument Convert(JObject sourceMember, ResolutionContext context)
         {
-            var ms = new MemoryStream();
+            using (var ms = new MemoryStream())
             using (BsonDataWriter writer = new BsonDataWriter(ms))
             {
                 sourceMember.WriteTo(writer);
+                return BsonSerializer.Deserialize(ms.ToArray());
             }
-
-            return BsonSerializer.Deserialize(ms.ToArray());
         }
     }
 }

--- a/Decsys/Services/ParticipantEventService.cs
+++ b/Decsys/Services/ParticipantEventService.cs
@@ -197,6 +197,8 @@ namespace Decsys.Services
             return ParticipantResultsSummary(instance, participantId);
         }
 
+
+
         private Models.ParticipantResultsSummary ParticipantResultsSummary(SurveyInstance instance, string participantId)
         {
             var log = _db.GetCollection<ParticipantEvent>(GetCollectionName(instance.Id, participantId));

--- a/Decsys/Services/ParticipantEventService.cs
+++ b/Decsys/Services/ParticipantEventService.cs
@@ -197,8 +197,6 @@ namespace Decsys.Services
             return ParticipantResultsSummary(instance, participantId);
         }
 
-
-
         private Models.ParticipantResultsSummary ParticipantResultsSummary(SurveyInstance instance, string participantId)
         {
             var log = _db.GetCollection<ParticipantEvent>(GetCollectionName(instance.Id, participantId));


### PR DESCRIPTION
The results summary for a survey instance (run) can now be provided flattened into a CSV, instead of the hierarchical JSON version