### PR TITLE
Import with data

### DIFF
--- a/Decsys/Auth/AuthPolicies.cs
+++ b/Decsys/Auth/AuthPolicies.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Decsys.Auth
+{
+    /// <summary>
+    /// Contains static helpers to build common Authorisation Policies
+    /// </summary>
+    public static class AuthPolicies
+    {
+        public static AuthorizationPolicy LocalHost()
+            => new AuthorizationPolicyBuilder()
+                .AddRequirements(new LocalMachineRequirement())
+                .Build();
+    }
+}

--- a/Decsys/Auth/AuthRequirements.cs
+++ b/Decsys/Auth/AuthRequirements.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+//This file contains stub requirements
+
+namespace Decsys.Auth
+{
+    /// <summary>
+    /// Requires that the site is being requested from the machine running the server
+    /// </summary>
+    public class LocalMachineRequirement : IAuthorizationRequirement { }
+}

--- a/Decsys/Auth/LocalMachineHandler.cs
+++ b/Decsys/Auth/LocalMachineHandler.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Decsys.Auth
+{
+    /// <summary>
+    /// Extremely naive handler for LocalMachineRequirement.
+    /// Requires use with MVC.
+    /// </summary>
+    public class LocalMachineHandler : AuthorizationHandler<LocalMachineRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, LocalMachineRequirement requirement)
+        {
+            if (context.Resource is AuthorizationFilterContext mvcContext)
+            {
+                if (mvcContext.HttpContext.Request.Host.Host == "localhost")
+                    context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Decsys/ClientApp/package.json
+++ b/Decsys/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "private": true,
   "dependencies": {
     "@decsys/param-types": "^1.0.0-beta.2",

--- a/Decsys/ClientApp/src/app/api.js
+++ b/Decsys/ClientApp/src/app/api.js
@@ -45,17 +45,22 @@ export const setComponentParam = (
     }
   );
 
-const uploadFile = (url, file, method = "post") => {
+const uploadFile = async (url, file, method = "post") => {
   const formData = new FormData();
   formData.append("file", file);
-  Axios[method](url, formData, {
+  await Axios[method](url, formData, {
     headers: {
       "content-type": "multipart/form-data"
     }
   });
 };
 
-export const uploadComponentImage = (surveyId, pageId, componentId, file) =>
+export const uploadComponentImage = async (
+  surveyId,
+  pageId,
+  componentId,
+  file
+) =>
   uploadFile(
     `/api/surveys/${surveyId}/pages/${pageId}/components/${componentId}/image`,
     file,
@@ -67,7 +72,7 @@ export const deleteComponentImage = (surveyId, pageId, componentId) =>
     `/api/surveys/${surveyId}/pages/${pageId}/components/${componentId}/image`
   );
 
-export const uploadSurveyImport = (file, importData = false) =>
+export const uploadSurveyImport = async (file, importData = false) =>
   uploadFile(`api/surveys/import?importData=${importData}`, file);
 
 export const createSurveyPage = id => Axios.post(`/api/surveys/${id}/pages`);

--- a/Decsys/ClientApp/src/app/api.js
+++ b/Decsys/ClientApp/src/app/api.js
@@ -67,8 +67,8 @@ export const deleteComponentImage = (surveyId, pageId, componentId) =>
     `/api/surveys/${surveyId}/pages/${pageId}/components/${componentId}/image`
   );
 
-export const uploadSurveyImport = file =>
-  uploadFile("api/surveys/import", file);
+export const uploadSurveyImport = (file, importData = false) =>
+  uploadFile(`api/surveys/import?importData=${importData}`, file);
 
 export const createSurveyPage = id => Axios.post(`/api/surveys/${id}/pages`);
 

--- a/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/PureSurveysScreen.js
+++ b/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/PureSurveysScreen.js
@@ -1,6 +1,15 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { Typography, Button, Alert, Box, Input } from "@smooth-ui/core-sc";
+import {
+  Typography,
+  Button,
+  Alert,
+  Box,
+  Input,
+  Checkbox,
+  FormCheck,
+  FormCheckLabel
+} from "@smooth-ui/core-sc";
 import {
   List,
   PlusCircle,
@@ -15,7 +24,9 @@ import ConfirmModal, { useModal } from "../../../components/ui/ConfirmModal";
 const SurveysScreen = ({ surveys, onCreateClick, onImportClick }) => {
   const importModal = useModal();
   const [importFile, setImportFile] = useState();
+  const [importData, setImportData] = useState(false);
   const [error, setError] = useState();
+  const idTimestamp = new Date().getTime();
 
   const handleFileSelect = e => {
     setImportFile();
@@ -33,7 +44,12 @@ const SurveysScreen = ({ surveys, onCreateClick, onImportClick }) => {
 
   const handleImportClick = () => {
     if (!importFile || error) return;
-    onImportClick(importFile);
+    onImportClick(importFile, importData);
+    importModal.toggleModal();
+  };
+
+  const handleImportDataCheckboxChange = e => {
+    setImportData(e.target.checked);
   };
 
   return (
@@ -97,6 +113,19 @@ const SurveysScreen = ({ surveys, onCreateClick, onImportClick }) => {
               <ExclamationCircle size="1em" /> {error}
             </Typography>
           )}
+
+          <FormCheck mt={2}>
+            <Checkbox
+              control
+              size="lg"
+              id={`import-data-${idTimestamp}`}
+              checked={importData}
+              onChange={handleImportDataCheckboxChange}
+            />
+            <FormCheckLabel htmlFor={`import-data-${idTimestamp}`}>
+              Also import any Results Data
+            </FormCheckLabel>
+          </FormCheck>
         </FlexBox>
       </ConfirmModal>
     </>

--- a/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/SurveysScreen.js
+++ b/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/SurveysScreen.js
@@ -16,7 +16,8 @@ const SurveysScreen = ({ surveys }) => {
   const navigation = useNavigation();
 
   const handleCreateClick = () => dispatch(ducks.createSurvey());
-  const handleImportClick = file => dispatch(ducks.importSurvey(file));
+  const handleImportClick = (file, importData) =>
+    dispatch(ducks.importSurvey(file, importData));
 
   const surveyCardActions = {
     handleEditClick: id => navigation.navigate(`admin/survey/${id}`), // TODO: Routing state for placeholder?

--- a/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/ducks/ops.js
+++ b/Decsys/ClientApp/src/app/screens/admin/SurveysScreen/ducks/ops.js
@@ -2,17 +2,14 @@ import * as actions from "./actions";
 import * as api from "../../../../api";
 
 export const createSurvey = () => async (_, nav) => {
-  // create the survey
   const { data: id } = await api.createSurvey();
-  // redirect to the editor with this survey
-  //await dispatch(setSurveyPlaceholder("Untitled Survey")); // TODO: Routing state?
   nav.navigate(`admin/survey/${id}`);
 };
 
-export const importSurvey = file => async (_, nav) => {
-  await api.uploadSurveyImport(file);
-  // then what?
-  nav.navigate("admin"); //ugh
+export const importSurvey = (file, importData) => async dispatch => {
+  await api.uploadSurveyImport(file, importData);
+  const { data: surveyList } = await api.listSurveys();
+  dispatch(actions.fetchSurveys(surveyList));
 };
 
 export const deleteSurvey = id => async dispatch => {

--- a/Decsys/Controllers/SurveysController.cs
+++ b/Decsys/Controllers/SurveysController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Decsys.Models;
@@ -177,7 +178,7 @@ namespace Decsys.Controllers
                         }
                         catch (JsonSerializationException)
                         {
-                            // This is fine
+                            // This is fine 🔥🍵🐕🔥
                             // We just don't import what we can't deserialize as an instance
                             // TODO: Maybe someday we could report on the result of our attempted import /shrug
                         }
@@ -188,7 +189,14 @@ namespace Decsys.Controllers
             if (survey is null)
                 return BadRequest("The uploaded file doesn't contain a valid Survey Structure file.");
 
-            return await _surveys.Import(survey, images);
+            var surveyId = await _surveys.Import(survey, images);
+
+            if (importData && instances.Any())
+            {
+                // attempt to import instances
+            }
+
+            return surveyId;
         }
     }
 }

--- a/Decsys/Controllers/SurveysController.cs
+++ b/Decsys/Controllers/SurveysController.cs
@@ -19,12 +19,14 @@ namespace Decsys.Controllers
     public class SurveysController : ControllerBase
     {
         private readonly SurveyService _surveys;
+        private readonly SurveyInstanceService _instances;
         private readonly ExportService _export;
 
-        public SurveysController(SurveyService surveys, ExportService export)
+        public SurveysController(SurveyService surveys, ExportService export, SurveyInstanceService instances)
         {
             _surveys = surveys;
             _export = export;
+            _instances = instances;
         }
 
         [HttpGet]
@@ -194,7 +196,7 @@ namespace Decsys.Controllers
             if (importData && instances.Any())
             {
                 // attempt to import instances
-
+                _instances.Import(instances, surveyId);
             }
 
             return surveyId;

--- a/Decsys/Controllers/SurveysController.cs
+++ b/Decsys/Controllers/SurveysController.cs
@@ -146,7 +146,7 @@ namespace Decsys.Controllers
         {
             Survey survey = null;
             var images = new List<(string filename, byte[] data)>();
-            var instances = new List<SurveyInstance>();
+            var instances = new List<SurveyInstanceResults<ParticipantEvents>>();
             using (var stream = new MemoryStream())
             {
                 await file.CopyToAsync(stream).ConfigureAwait(false);
@@ -174,7 +174,7 @@ namespace Decsys.Controllers
                         try
                         {
                             using (var reader = new StreamReader(entry.Open(), Encoding.UTF8))
-                                instances.Add(JsonConvert.DeserializeObject<SurveyInstance>(reader.ReadToEnd()));
+                                instances.Add(JsonConvert.DeserializeObject<SurveyInstanceResults<ParticipantEvents>>(reader.ReadToEnd()));
                         }
                         catch (JsonSerializationException)
                         {
@@ -194,6 +194,7 @@ namespace Decsys.Controllers
             if (importData && instances.Any())
             {
                 // attempt to import instances
+
             }
 
             return surveyId;

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -49,7 +49,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Auth\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.0-beta.3</Version>
+    <Version>1.0.0-beta.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -49,6 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Auth\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/Decsys/Mapping/SurveyInstanceMaps.cs
+++ b/Decsys/Mapping/SurveyInstanceMaps.cs
@@ -21,8 +21,7 @@ namespace Decsys.Mapping
                 .ForMember(dest => dest.Survey, opt => opt.Ignore()); // do this manually as we don't export the id
 
             CreateMap(typeof(Models.SurveyInstanceResults<>), typeof(SurveyInstance))
-                .IncludeBase(typeof(Models.BaseSurveyInstanceResults), typeof(SurveyInstance))
-                .ForMember("Participants", opt => opt.Ignore());
+                .IncludeBase(typeof(Models.BaseSurveyInstanceResults), typeof(SurveyInstance));
         }
     }
 }

--- a/Decsys/Mapping/SurveyInstanceMaps.cs
+++ b/Decsys/Mapping/SurveyInstanceMaps.cs
@@ -9,19 +9,19 @@ namespace Decsys.Mapping
         public SurveyInstanceMaps()
         {
             CreateMap<SurveyInstance, Models.BaseSurveyInstanceResults>()
-                .ForMember(dest => dest.Generated, opt => opt.MapFrom(src => DateTime.UtcNow))
-                .ForMember(dest => dest.InstancePublished, opt => opt.MapFrom(src => src.Published))
-                .ForMember(dest => dest.InstanceClosed, opt => opt.MapFrom(src => src.Closed))
-                .ForMember(dest => dest.Survey, opt => opt.MapFrom(src => src.Survey.Name))
-                .ForMember(dest => dest.Config, opt => opt.MapFrom(src => new
-                    {
-                        src.OneTimeParticipants,
-                        src.UseParticipantIdentifiers,
-                        src.ValidIdentifiers
-                    }));
+                .ForMember(dest => dest.ExportGenerated, opt => opt.MapFrom(src => DateTime.UtcNow))
+                .ForMember(dest => dest.Survey, opt => opt.MapFrom(src => src.Survey.Name));
 
             CreateMap(typeof(SurveyInstance), typeof(Models.SurveyInstanceResults<>))
                 .IncludeBase(typeof(SurveyInstance), typeof(Models.BaseSurveyInstanceResults))
+                .ForMember("Participants", opt => opt.Ignore());
+
+            // These are only used for imports!
+            CreateMap<Models.BaseSurveyInstanceResults, SurveyInstance>()
+                .ForMember(dest => dest.Survey, opt => opt.Ignore()); // do this manually as we don't export the id
+
+            CreateMap(typeof(Models.SurveyInstanceResults<>), typeof(SurveyInstance))
+                .IncludeBase(typeof(Models.BaseSurveyInstanceResults), typeof(SurveyInstance))
                 .ForMember("Participants", opt => opt.Ignore());
         }
     }

--- a/Decsys/Mapping/SurveyInstanceMaps.cs
+++ b/Decsys/Mapping/SurveyInstanceMaps.cs
@@ -18,6 +18,7 @@ namespace Decsys.Mapping
 
             // These are only used for imports!
             CreateMap<Models.BaseSurveyInstanceResults, SurveyInstance>()
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => 0))// always set to 0; we are inserting new instances
                 .ForMember(dest => dest.Survey, opt => opt.Ignore()); // do this manually as we don't export the id
 
             CreateMap(typeof(Models.SurveyInstanceResults<>), typeof(SurveyInstance))

--- a/Decsys/Mapping/SurveyInstanceMaps.cs
+++ b/Decsys/Mapping/SurveyInstanceMaps.cs
@@ -1,0 +1,28 @@
+﻿using AutoMapper;
+using Decsys.Data.Entities;
+using System;
+
+namespace Decsys.Mapping
+{
+    public class SurveyInstanceMaps : Profile
+    {
+        public SurveyInstanceMaps()
+        {
+            CreateMap<SurveyInstance, Models.BaseSurveyInstanceResults>()
+                .ForMember(dest => dest.Generated, opt => opt.MapFrom(src => DateTime.UtcNow))
+                .ForMember(dest => dest.InstancePublished, opt => opt.MapFrom(src => src.Published))
+                .ForMember(dest => dest.InstanceClosed, opt => opt.MapFrom(src => src.Closed))
+                .ForMember(dest => dest.Survey, opt => opt.MapFrom(src => src.Survey.Name))
+                .ForMember(dest => dest.Config, opt => opt.MapFrom(src => new
+                    {
+                        src.OneTimeParticipants,
+                        src.UseParticipantIdentifiers,
+                        src.ValidIdentifiers
+                    }));
+
+            CreateMap(typeof(SurveyInstance), typeof(Models.SurveyInstanceResults<>))
+                .IncludeBase(typeof(SurveyInstance), typeof(Models.BaseSurveyInstanceResults))
+                .ForMember("Participants", opt => opt.Ignore());
+        }
+    }
+}

--- a/Decsys/Models/SurveyInstanceResults.cs
+++ b/Decsys/Models/SurveyInstanceResults.cs
@@ -10,29 +10,30 @@ namespace Decsys.Models
     public class BaseSurveyInstanceResults
     {
         /// <summary>
-        /// A timestamp for when the summary was produced
+        /// A timestamp for when the export was produced
         /// </summary>
-        public DateTimeOffset Generated { get; set; }
+        public DateTimeOffset ExportGenerated { get; set; }
 
         /// <summary>
         /// The timestamp which identifies the Survey Instance, by when it was published
         /// </summary>
-        public DateTimeOffset InstancePublished { get; set; }
+        public DateTimeOffset Published { get; set; }
 
         /// <summary>
         /// The timestamp for when the Survey was closed, if it has been
         /// </summary>
-        public DateTimeOffset? InstanceClosed { get; set; }
+        public DateTimeOffset? Closed { get; set; }
 
         /// <summary>
         /// The name of the survey the instance (and therefore these results) belong to
         /// </summary>
         public string Survey { get; set; } = string.Empty;
 
-        /// <summary>
-        /// The Survey Config that was used at the time of publishing this instance
-        /// </summary>
-        public object Config { get; set; } = new { };
+        public bool OneTimeParticipants { get; set; }
+
+        public bool UseParticipantIdentifiers { get; set; }
+
+        public IEnumerable<string> ValidIdentifiers { get; set; } = new List<string>();
     }
 
     /// <summary>

--- a/Decsys/Models/SurveyInstanceResults.cs
+++ b/Decsys/Models/SurveyInstanceResults.cs
@@ -5,9 +5,9 @@ namespace Decsys.Models
 {
 
     /// <summary>
-    /// An export model for the results data of a survey instance
+    /// A base export model for the results data of a survey instance
     /// </summary>
-    public class SurveyInstanceResults<T>
+    public class BaseSurveyInstanceResults
     {
         /// <summary>
         /// A timestamp for when the summary was produced
@@ -15,15 +15,32 @@ namespace Decsys.Models
         public DateTimeOffset Generated { get; set; }
 
         /// <summary>
-        /// The timestamp which identifies the Survey Instance
+        /// The timestamp which identifies the Survey Instance, by when it was published
         /// </summary>
-        public DateTimeOffset Instance { get; set; }
+        public DateTimeOffset InstancePublished { get; set; }
+
+        /// <summary>
+        /// The timestamp for when the Survey was closed, if it has been
+        /// </summary>
+        public DateTimeOffset? InstanceClosed { get; set; }
 
         /// <summary>
         /// The name of the survey the instance (and therefore these results) belong to
         /// </summary>
         public string Survey { get; set; } = string.Empty;
 
+        /// <summary>
+        /// The Survey Config that was used at the time of publishing this instance
+        /// </summary>
+        public object Config { get; set; } = new { };
+    }
+
+    /// <summary>
+    /// A generic export model for the results data of a survey instance
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class SurveyInstanceResults<T> : BaseSurveyInstanceResults
+    {
         /// <summary>
         /// The instance participants and their export data
         /// </summary>

--- a/Decsys/Services/ParticipantEventService.cs
+++ b/Decsys/Services/ParticipantEventService.cs
@@ -56,7 +56,7 @@ namespace Decsys.Services
             // Get all participant collections for this instance
             var logs = GetAllParticipantLogs(instanceId);
 
-            // summarize each one
+            // Add each one
             var participants = new List<Models.ParticipantEvents>();
             foreach (var collectionName in logs)
             {
@@ -68,13 +68,10 @@ namespace Decsys.Services
                 });
             }
 
-            return new Models.SurveyInstanceResults<Models.ParticipantEvents>
-            {
-                Generated = DateTimeOffset.UtcNow,
-                Instance = instance.Published,
-                Survey = instance.Survey.Name,
-                Participants = participants
-            };
+            var result = _mapper.Map<Models.SurveyInstanceResults<Models.ParticipantEvents>>(instance);
+            result.Participants = participants;
+
+            return result;
         }
 
         /// <summary>
@@ -165,13 +162,10 @@ namespace Decsys.Services
                 participants.Add(ParticipantResultsSummary(instance, participantId));
             }
 
-            return new Models.SurveyInstanceResults<Models.ParticipantResultsSummary>
-            {
-                Generated = DateTimeOffset.UtcNow,
-                Instance = instance.Published,
-                Survey = instance.Survey.Name,
-                Participants = participants
-            };
+            var result = _mapper.Map<Models.SurveyInstanceResults<Models.ParticipantResultsSummary>>(instance);
+            result.Participants = participants;
+
+            return result;
         }
 
         /// <summary>

--- a/Decsys/Services/ParticipantEventService.cs
+++ b/Decsys/Services/ParticipantEventService.cs
@@ -22,7 +22,7 @@ namespace Decsys.Services
             _mapper = mapper;
         }
 
-        private string GetCollectionName(int instanceId, string participantId)
+        public static string GetCollectionName(int instanceId, string participantId)
             => $"{Collections.EventLog}{instanceId}_{participantId}";
 
         private IEnumerable<Models.ParticipantEvent> _List(int instanceId, string participantId)

--- a/Decsys/Services/ParticipantEventService.cs
+++ b/Decsys/Services/ParticipantEventService.cs
@@ -44,7 +44,6 @@ namespace Decsys.Services
             return _List(instanceId, participantId);
         }
 
-        // TODO: refactor export types and their inheritance / genericness
         public Models.SurveyInstanceResults<Models.ParticipantEvents> Results(int instanceId)
         {
             var instance = _db.GetCollection<SurveyInstance>(

--- a/Decsys/Services/SurveyInstanceService.cs
+++ b/Decsys/Services/SurveyInstanceService.cs
@@ -84,5 +84,10 @@ namespace Decsys.Services
             instance.Closed = DateTimeOffset.UtcNow;
             instances.Update(instance);
         }
+
+        public void Import(IList<Models.SurveyInstance> instances, int targetSurveyId)
+        {
+
+        }
     }
 }

--- a/Decsys/Services/SurveyInstanceService.cs
+++ b/Decsys/Services/SurveyInstanceService.cs
@@ -85,9 +85,28 @@ namespace Decsys.Services
             instances.Update(instance);
         }
 
-        public void Import(IList<Models.SurveyInstance> instances, int targetSurveyId)
+        public void Import(IList<Models.SurveyInstanceResults<Models.ParticipantEvents>> instanceModels, int targetSurveyId)
         {
+            var instances = _db.GetCollection<SurveyInstance>(Collections.SurveyInstances);
+            var survey = _db.GetCollection<Survey>(Collections.Surveys).FindById(targetSurveyId);
 
+            foreach (var instanceModel in instanceModels)
+            {
+                var instance = _mapper.Map<SurveyInstance>(instanceModel);
+                instance.Survey = survey;
+                var instanceId = instances.Insert(instance);
+
+                foreach(var participant in instanceModel.Participants)
+                {
+                    var log = _db.GetCollection<ParticipantEvent>(
+                    ParticipantEventService.GetCollectionName(instanceId, participant.Id));
+
+                    foreach(var e in participant.Events)
+                    {
+                        log.Insert(_mapper.Map<ParticipantEvent>(e));
+                    }
+                }
+            }
         }
     }
 }

--- a/Decsys/Startup.cs
+++ b/Decsys/Startup.cs
@@ -1,7 +1,9 @@
 using AutoMapper;
 using ClacksMiddleware.Extensions;
+using Decsys.Auth;
 using Decsys.Services;
 using LiteDB;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -36,6 +38,13 @@ namespace Decsys
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Add Authorization
+            services.AddAuthorization(opts => opts.AddPolicy(
+                nameof(AuthPolicies.LocalHost),
+                AuthPolicies.LocalHost()));
+
+            services.AddSingleton<IAuthorizationHandler, LocalMachineHandler>();
+
             services.AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 


### PR DESCRIPTION
- Importing Surveys now offers the option to bring in any results data, if the export included it.
- fixed the import dialog not refreshing the Survey List automatically after import.
- fixed some backend authorisation policies
- accidentally fixed image upload async race conditions that seemed to affect Edge Classic more then Chrome. Either way, these are properly awaited now and so the race is irrelevant.
- 