### PR TITLE
Db collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-decsys*.db
+local-data
 version.txt
 Decsys/components
 Decsys/SurveyImages

--- a/Decsys/Data/Collections.cs
+++ b/Decsys/Data/Collections.cs
@@ -6,7 +6,9 @@ namespace Decsys.Data
 
         public const string SurveyInstances = "SurveyInstances";
 
-        public const string EventLog = "Events_";
+        public const string EventLogDb = "events_";
+
+        public const string EventLog = "e";
 
         public const string EventLogLookup = "l";
     }

--- a/Decsys/Data/Collections.cs
+++ b/Decsys/Data/Collections.cs
@@ -1,4 +1,4 @@
-﻿namespace Decsys.Data
+namespace Decsys.Data
 {
     public static class Collections
     {
@@ -7,5 +7,7 @@
         public const string SurveyInstances = "SurveyInstances";
 
         public const string EventLog = "Events_";
+
+        public const string EventLogLookup = "l";
     }
 }

--- a/Decsys/Data/Entities/EventLogLookup.cs
+++ b/Decsys/Data/Entities/EventLogLookup.cs
@@ -1,0 +1,9 @@
+namespace Decsys.Data.Entities
+{
+    public class EventLogLookup
+    {
+        public int Id { get; set; }
+
+        public string ParticipantId { get; set; } = string.Empty;
+    }
+}

--- a/Decsys/Data/LiteDbFactory.cs
+++ b/Decsys/Data/LiteDbFactory.cs
@@ -20,7 +20,7 @@ namespace Decsys.Data
         private const string SurveysFile = "user-surveys.db";
 
         private static string InstanceEventLogsFile(int instanceId)
-            => $"{Collections.EventLog}{instanceId}.db";
+            => $"{Collections.EventLogDb}{instanceId}.db";
 
         private string BuildConnectionString(string file)
             => $"Filename={Path.Combine(_localDbPath, file)};Connection=direct;";

--- a/Decsys/Data/LiteDbFactory.cs
+++ b/Decsys/Data/LiteDbFactory.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using LiteDB;
+
+namespace Decsys.Data
+{
+    /// <summary>
+    /// Instantiate connections for LiteDb databases on request and manages their lifetimes
+    /// </summary>
+    public class LiteDbFactory : IDisposable
+    {
+        private readonly string _localDbPath;
+
+        public LiteDbFactory(string localDbPath)
+        {
+            _localDbPath = localDbPath;
+        }
+
+        private const string SurveysFile = "user-surveys.db";
+
+        private static string InstanceEventLogsFile(int instanceId)
+            => $"{Collections.EventLog}{instanceId}.db";
+
+        private string BuildConnectionString(string file)
+            => $"Filename={Path.Combine(_localDbPath, file)};Connection=direct;";
+
+        private IDictionary<string, LiteDatabase> _connections = new Dictionary<string, LiteDatabase>();
+
+        private LiteDatabase Connect(string connectionString)
+        {
+            if (!_connections.ContainsKey(connectionString))
+                _connections[connectionString] = new LiteDatabase(connectionString);
+            return _connections[connectionString];
+        }
+
+        public LiteDatabase Surveys => Connect(BuildConnectionString(SurveysFile));
+
+        public LiteDatabase InstanceEventLogs(int instanceId)
+            => Connect(BuildConnectionString(InstanceEventLogsFile(instanceId)));
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool managed)
+        {
+            if (managed)
+                foreach (var db in _connections.Values)
+                    db.Dispose();
+        }
+    }
+}

--- a/Decsys/Decsys.csproj
+++ b/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Decsys/Services/ComponentService.cs
+++ b/Decsys/Services/ComponentService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
@@ -18,9 +18,9 @@ namespace Decsys.Services
         private readonly IMapper _mapper;
         private readonly ImageService _images;
 
-        public ComponentService(LiteDatabase db, IMapper mapper, ImageService images)
+        public ComponentService(LiteDbFactory db, IMapper mapper, ImageService images)
         {
-            _db = db;
+            _db = db.Surveys;
             _mapper = mapper;
             _images = images;
         }

--- a/Decsys/Services/PageService.cs
+++ b/Decsys/Services/PageService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
@@ -17,9 +17,9 @@ namespace Decsys.Services
         private readonly IMapper _mapper;
         private readonly ImageService _images;
 
-        public PageService(LiteDatabase db, IMapper mapper, ImageService images)
+        public PageService(LiteDbFactory db, IMapper mapper, ImageService images)
         {
-            _db = db;
+            _db = db.Surveys;
             _mapper = mapper;
             _images = images;
         }

--- a/Decsys/Services/SurveyInstanceService.cs
+++ b/Decsys/Services/SurveyInstanceService.cs
@@ -99,7 +99,7 @@ namespace Decsys.Services
                 foreach(var participant in instanceModel.Participants)
                 {
                     var log = _db.InstanceEventLogs(instanceId).GetCollection<ParticipantEvent>(
-                    ParticipantEventService.GetCollectionName(instanceId, participant.Id));
+                    ParticipantEventService.GetCollectionName(participant.Id, _db.InstanceEventLogs(instanceId)));
 
                     foreach(var e in participant.Events)
                     {

--- a/Decsys/Services/SurveyService.cs
+++ b/Decsys/Services/SurveyService.cs
@@ -18,9 +18,9 @@ namespace Decsys.Services
         private readonly ImageService _images;
 
         /// <summary>DI Constructor</summary>
-        public SurveyService(LiteDatabase db, IMapper mapper, ImageService images)
+        public SurveyService(LiteDbFactory db, IMapper mapper, ImageService images)
         {
-            _db = db;
+            _db = db.Surveys;
             _mapper = mapper;
             _images = images;
         }

--- a/Decsys/appsettings.json
+++ b/Decsys/appsettings.json
@@ -5,10 +5,8 @@
     }
   },
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "DocumentStore": "Filename=decsys.db;Upgrade=true"
-  },
   "Paths": {
+    "LocalData": "local-data",
     "Components": { "Root": "components" }
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
   - master
+  - support/*
 variables:
   buildConfiguration: Release
 stages:
@@ -154,7 +155,14 @@ stages:
           - publish: $(Build.ArtifactStagingDirectory)
             artifact: $(name)
   - stage: Release
-    condition: "and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))"
+    condition: >
+      and(
+        succeeded(),
+        or(
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/support/'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        )
+      )
     jobs:
       - job: Metadata
         pool:
@@ -169,6 +177,7 @@ stages:
               variable=apiVersion;isOutput=true]$(csproj_Project_PropertyGroup_0_Version)'
             name: setApiVersion
       - deployment: GitHub_Pages
+        condition: "eq(variables['Build.SourceBranch'], 'refs/heads/master')"
         pool:
           vmImage: ubuntu-latest
         environment: github


### PR DESCRIPTION
fixes AZ#19651

we now use multiple LiteDb files on disk, to relax limits around collections and records within them.

Surveys and their instances are kept in one DB, with a collection each, and references from instances to their parent surveys.

Instance event data is now stored in a DB *per-instance*, with a collection *per participant ID*.

collection names in Event DB's are very short, and resolved to participant id's by a lookup collection, as that is one way LiteDB limits database sizes.

There is still a bug (AZ#22026) causing superfluous collection creation in event DB's, hich should be resolved in the near future.