### PR TITLE
✨ Import migration

### DIFF
--- a/app/Decsys/Config/ComponentTypeMap.cs
+++ b/app/Decsys/Config/ComponentTypeMap.cs
@@ -1,0 +1,10 @@
+﻿
+using System.Collections.Generic;
+
+namespace Decsys.Config
+{
+    public class ComponentTypeMap
+    {
+        public Dictionary<string, string> Types { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/app/Decsys/Config/Versions.cs
+++ b/app/Decsys/Config/Versions.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Decsys.Config
+{
+    public static class Versions
+    {
+        public const string v1 = "v1";
+        public const string v2 = "v2";
+
+        public static readonly string[] All = new[] { v1, v2 };
+    }
+}

--- a/app/Decsys/Mapping/SurveyInstanceMaps.cs
+++ b/app/Decsys/Mapping/SurveyInstanceMaps.cs
@@ -8,15 +8,15 @@ namespace Decsys.Mapping
     {
         public SurveyInstanceMaps()
         {
-            CreateMap<SurveyInstance, Models.BaseSurveyInstanceResults>()
+            CreateMap<Models.SurveyInstance, Models.BaseSurveyInstanceResults>()
                 .ForMember(dest => dest.ExportGenerated, opt => opt.MapFrom(_ => DateTime.UtcNow))
                 .ForMember(dest => dest.Survey, opt => opt.MapFrom(src => src.Survey.Name));
 
-            CreateMap(typeof(SurveyInstance), typeof(Models.SurveyInstanceResults<>))
-                .IncludeBase(typeof(SurveyInstance), typeof(Models.BaseSurveyInstanceResults))
+            CreateMap(typeof(Models.SurveyInstance), typeof(Models.SurveyInstanceResults<>))
+                .IncludeBase(typeof(Models.SurveyInstance), typeof(Models.BaseSurveyInstanceResults))
                 .ForMember("Participants", opt => opt.Ignore());
 
-            // These are only used for imports!
+            // These are only used for imports! // TODO: gonna need to fix these
             CreateMap<Models.BaseSurveyInstanceResults, SurveyInstance>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(_ => 0))// always set to 0; we are inserting new instances
                 .ForMember(dest => dest.Survey, opt => opt.Ignore()); // do this manually as we don't export the id

--- a/app/Decsys/Program.cs
+++ b/app/Decsys/Program.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Decsys
@@ -10,7 +12,13 @@ namespace Decsys
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(b =>
-                    b.UseStartup<Startup>());
+            .ConfigureAppConfiguration((context, b) =>
+                b.AddJsonFile(
+                    Path.Combine(
+                        context.HostingEnvironment.ContentRootPath,
+                        "settings/component-type-maps.json"),
+                    optional: false))
+            .ConfigureWebHostDefaults(b =>
+                b.UseStartup<Startup>());
     }
 }

--- a/app/Decsys/Startup.cs
+++ b/app/Decsys/Startup.cs
@@ -29,6 +29,7 @@ using UoN.AspNetCore.VersionMiddleware;
 using UoN.VersionInformation;
 using UoN.VersionInformation.DependencyInjection;
 using UoN.VersionInformation.Providers;
+using Decsys.Config;
 
 #pragma warning disable 1591
 namespace Decsys
@@ -75,6 +76,12 @@ namespace Decsys
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            foreach (var v in Versions.All)
+                services.Configure<ComponentTypeMap>(v,
+                    c => _config
+                        .GetSection($"ComponentTypeMaps:{v}")
+                        .Bind(c.Types));
+
             services.AddSingleton(_ => new LiteDbFactory(_localPaths["Databases"]));
 
             services.AddResponseCompression();

--- a/app/Decsys/settings/component-type-maps.json
+++ b/app/Decsys/settings/component-type-maps.json
@@ -1,0 +1,14 @@
+{
+  "ComponentTypeMaps": {
+    "v1": {
+      "13484d8e-fd9e-4e48-99ac-5657c9df30dc": "Ellipse",
+      "8f07de7a-c9b2-4dbe-afa2-1e3beabf4d3d": "Discrete",
+      "ff6eb986-2124-4e65-83b0-ddf8b67ffc77": "FreeText"
+    },
+    "v2": {
+      "13484d8e-fd9e-4e48-99ac-5657c9df30dc": "Ellipse Scale",
+      "8f07de7a-c9b2-4dbe-afa2-1e3beabf4d3d": "Discrete Scale",
+      "ff6eb986-2124-4e65-83b0-ddf8b67ffc77": "Free Text"
+    }
+  }
+}

--- a/app/client-app/src/services/export.js
+++ b/app/client-app/src/services/export.js
@@ -43,7 +43,9 @@ const b64toByteArrays = (b64Data, sliceSize = 512) => {
  * Download survey structure as a json file
  */
 export const surveyExport = async (id, name, type) => {
-  const filename = `Survey-${name}_${exportDateFormat(new Date())}_${type}`;
+  const filename = `Survey-${name}_${
+    exportDateFormat(new Date()).flat
+  }_${type}`;
   const mime = "application/zip";
   const { data } = await api.getSurveyExport(id, type);
   return downloadFile(b64toByteArrays(data), `${filename}.zip`, mime);


### PR DESCRIPTION
between v1 and v2 of the platform, not much of the public interface has changed, but some of the shipped resposne item names have.

Imported surveys from 1.x will reference the old names, and those components won't be found.

So now we migrate those namaes during import.

This implementation also gives a glimpse into how we can manage more complex mapping in future, if we start putting versions in exports.