### PR TITLE
⚡ added non-single file win64 output for azure

### DIFF
--- a/.azure/pipelines/decsys.publish.yml
+++ b/.azure/pipelines/decsys.publish.yml
@@ -135,12 +135,15 @@ stages:
           responseItemsArtifactPattern: "**/*.js"
         strategy:
           matrix:
-            win_x64:
+            win_x64_singlefile:
               name: win-x64
               args: >-
                 -r win-x64
                 -p:PublishSingleFile=true
                 -p:IncludeNativeLibrariesInSingleFile=true
+            win_x64:
+              name: win-x64
+              args: -r win-x64
             dotnet:
               name: dotnet-$(dotnetVersion)
               args: ""

--- a/.azure/pipelines/decsys.publish.yml
+++ b/.azure/pipelines/decsys.publish.yml
@@ -136,7 +136,7 @@ stages:
         strategy:
           matrix:
             win_x64_singlefile:
-              name: win-x64
+              name: win-x64-singlefile
               args: >-
                 -r win-x64
                 -p:PublishSingleFile=true


### PR DESCRIPTION
While we're running .NET 5 preview, we need to deploy self-contained builds of DECSYS (which include the correct .NET runtime version) to Azure (because it doesn't have .NET 5 installed on App Service yet.)

However, our distributable self-contained Windows builds are "single file" outputs, which is better for human consumers. IIS in App Service can't run single file apps though.

So for the time being, when we publish the app, we publish the following outputs:
- dotnet 5 (preview 8) runtime
- win-x64 self-contained single file 
- win-x64 self-contained (not single file - Azure App service compatible)