### PR TITLE
⚡ Better local usernames

### DIFF
--- a/app/Decsys/Auth/DataSeeder.cs
+++ b/app/Decsys/Auth/DataSeeder.cs
@@ -8,13 +8,24 @@ namespace Decsys.Auth
 {
     public static class DataSeeder
     {
+        const string _defaultAdminUsername = "admin";
+        const string _adminEmail = "admin@localhost";
+
         public static async Task Seed(
             UserManager<IdentityUser> users,
             IPasswordHasher<IdentityUser> passwords,
             IConfiguration config)
         {
             // Seed an initial super user to use for setup
-            var username = "admin@localhost";
+
+            
+            var configuredUsername = config["Hosted:AdminUsername"];
+            var username = string.IsNullOrWhiteSpace(configuredUsername)
+                ? _defaultAdminUsername
+                : configuredUsername;
+
+            // Prefix the username to show it's not an email
+            username = $"@{username}";
             if (await users.FindByNameAsync(username) is null)
             {
                 // check an actual password has been configured
@@ -30,7 +41,7 @@ or the environment variable DOTNET_Hosted_AdminPassword");
                 var user = new IdentityUser
                 {
                     UserName = username,
-                    Email = username,
+                    Email = _adminEmail,
                     EmailConfirmed = true
                 };
 

--- a/app/Decsys/Controllers/AccountController.cs
+++ b/app/Decsys/Controllers/AccountController.cs
@@ -19,7 +19,6 @@ namespace Decsys.Controllers
     public class LoginModel
     {
         [Required]
-        [EmailAddress]
         public string Username { get; set; } = string.Empty;
 
         [Required]

--- a/app/client-app/src/app/layouts/components/AppBar.js
+++ b/app/client-app/src/app/layouts/components/AppBar.js
@@ -28,12 +28,12 @@ const AppBar = ({ brand, children, brandLink }) => {
       boxShadow="section-h"
     >
       <Flex
-        w={{ base: "100%", lg: "1140px" }}
-        px={{ base: 2, xl: 0 }}
+        w={{ base: "100%", xl: "1140px" }}
+        px={{ base: 4, xl: 0 }}
         align="center"
         justify="space-between"
       >
-        <LightHeading size="lg" p={2}>
+        <LightHeading size="lg" py={2}>
           <AppBarLink as={RouterLink} to={brandLink}>
             {brand}
           </AppBarLink>

--- a/app/client-app/src/app/pages/Login/validation.js
+++ b/app/client-app/src/app/pages/Login/validation.js
@@ -8,9 +8,7 @@ export default object().shape({
       "Please enter a valid email address.",
       (v) =>
         string().email().isValidSync(v) ||
-        string()
-          .matches(/@localhost$/)
-          .isValidSync(v)
+        string().matches(/^\$/).isValidSync(v)
     )
     .required("Please enter your account email address."),
   Password: string().required("Please enter your account password."),

--- a/app/client-app/src/app/pages/Login/validation.js
+++ b/app/client-app/src/app/pages/Login/validation.js
@@ -7,8 +7,7 @@ export default object().shape({
       "valid-username",
       "Please enter a valid email address.",
       (v) =>
-        string().email().isValidSync(v) ||
-        string().matches(/^\$/).isValidSync(v)
+        string().email().isValidSync(v) || string().matches(/^@/).isValidSync(v)
     )
     .required("Please enter your account email address."),
   Password: string().required("Please enter your account password."),

--- a/docs/docs/users/installation.md
+++ b/docs/docs/users/installation.md
@@ -42,8 +42,8 @@ This section is under construction and may change.
 :::
 
 
-:::tip 🙋🏾‍♀️ Hosted mode Admin Username
-`admin@localhost`
+:::tip 🙋🏾‍♀️ Default Hosted mode Admin Username
+`@admin`
 :::
 
 ### Prerequisites
@@ -62,6 +62,10 @@ Then, you'll need to make some configuration changes as follows:
   - port `80` (http) or `443` (https) may be ommitted for those schemes.
 - Set `Hosted:AdminPassword` to the password for your admin user.
 - Set `Hosted:JwtSigningKey` to a [JSON Web Key](https://mkjwk.org)
+- [Optional] set `Hosted:AdminUsername` to a username for your admin user.
+  - The app will prefix this username with `@` to identify it as the system admin.
+  - if you set this in the config as `decsys`, then you'll need to login with `@decsys`.
+  - defaults to `admin`.
 
 #### DECSYS JSON Web Key Parameters
 


### PR DESCRIPTION
local usernames (currently just the single configured admin) no longer need to be email address formatted.

so the rather cumbersome and layperson unfriendly `admin@localhost` is now `@admin`.

we use the leading `@` to signify to the app that this username definitely isn't an email address.

the actual username is also now configurable by setting `Hosted:AdminUsername`.
