### PR TITLE
2.0.0-beta.2

### DIFF
--- a/app/Decsys/Decsys.csproj
+++ b/app/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>2.0.0-beta.1</Version>
+    <Version>2.0.0-beta.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/app/Decsys/Repositories/Mongo/SurveyRepository.cs
+++ b/app/Decsys/Repositories/Mongo/SurveyRepository.cs
@@ -68,7 +68,7 @@ namespace Decsys.Repositories.Mongo
             entity.Owner = ownerId;
 
             _surveys.InsertOne(entity);
-            return survey.Id;
+            return entity.Id;
         }
 
         public void Delete(int id)

--- a/app/client-app/package.json
+++ b/app/client-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "scripts": {
     "start": "craco start",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/response-items/choose-one/package.json
+++ b/response-items/choose-one/package.json
@@ -1,7 +1,7 @@
 {
   "name": "choose-one-response",
   "responseItemName": "Choose One",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Choose one from a selection of qualitative answers",
   "private": true,
   "author": "James Fleming <jamesfleming91@gmail.com>",

--- a/response-items/confirmation/package.json
+++ b/response-items/confirmation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "confirmation-response",
   "responseItemName": "Confirmation",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Confirmation Page Response Item for the DECSYS Survey Platform",
   "private": true,
   "author": "Jonathan Couldridge <jon@jon.gg>",

--- a/response-items/discrete-scale/package.json
+++ b/response-items/discrete-scale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discrete-scale-response",
   "responseItemName": "Discrete Scale",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "The Discrete Scale Page Response Item for the DECSYS Survey Platform",
   "private": true,
   "author": "Jonathan Couldridge <jon@jon.gg>",

--- a/response-items/ellipse-scale/package.json
+++ b/response-items/ellipse-scale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ellipse-scale-response",
   "responseItemName": "Ellipse Scale",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "The Ellipse Scale Page Response Item for the DECSYS Survey Platform",
   "private": true,
   "author": "Jonathan Couldridge <jon@jon.gg>",

--- a/response-items/freetext/package.json
+++ b/response-items/freetext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freetext-response",
   "responseItemName": "Free Text",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Free Text Page Response Item for the DECSYS Survey Platform",
   "private": true,
   "author": "Jonathan Couldridge <jon@jon.gg>",


### PR DESCRIPTION
just one tiny bugfix, but warrants immediate release.

When using mongo as the hosted datastore, creating a Survey from an existing Model (e.g. when duplicating or importing Surveys) returned the OLD Survey ID when proceeding to perform actions on Survey Images.

The new ID is now returned, and Survey Images are now correctly referenced.