### PR TITLE
⚡ Dashboard includes all pages

### DIFF
--- a/app/client-app/src/app/pages/Dashboard.js
+++ b/app/client-app/src/app/pages/Dashboard.js
@@ -43,6 +43,8 @@ const getDataByPage = (survey, results) => {
     }, {})
   );
 
+  console.log(resultsByPage, completionByPage);
+
   return {
     resultsByPage,
     completionByPage,
@@ -188,23 +190,31 @@ const Dashboard = ({ combinedId }) => {
         </Flex>
         {completionByPage?.length && (
           <Stack boxShadow="callout" spacing={0}>
-            {survey.pages.map(
-              (p, i) =>
-                !!getPageResponseItem(p.components) && (
-                  <ProgressCard
-                    key={i}
-                    title={`Q${i + 1}`}
-                    cardHeaderWidth="50px"
-                    total={results.participants.length}
-                    progressData={Object.keys(completionByPage[i]).map(
-                      (id) => ({
-                        complete: completionByPage[i][id],
-                      })
-                    )}
-                    onClick={() => handleCardClick(i)}
-                  />
-                )
-            )}
+            {survey.pages.map((_, i) => {
+              const completionData = completionByPage[i];
+              // Pages without responses will be nullish in resultsByPage
+              // so we use that to distinguish
+              const hasResponses = !!resultsByPage[i];
+              return (
+                <ProgressCard
+                  key={i}
+                  title={`Page ${i + 1}`}
+                  cardHeaderWidth="100px"
+                  total={results.participants.length}
+                  progressData={
+                    hasResponses &&
+                    Object.keys(completionData).map((id) => ({
+                      complete: completionData[id],
+                    }))
+                  }
+                  message={
+                    !hasResponses && "This page doesn't gather reponses."
+                  }
+                  lowProfile={!hasResponses}
+                  onClick={hasResponses && (() => handleCardClick(i))}
+                />
+              );
+            })}
           </Stack>
         )}
       </Stack>
@@ -213,7 +223,7 @@ const Dashboard = ({ combinedId }) => {
         <StandardModal
           {...statsModal}
           size="6xl"
-          header={`Q${statsPage.order} Stats`}
+          header={`Page ${statsPage.order} Stats`}
           cancelButton={false}
         >
           <Stats

--- a/app/client-app/src/components/core/ProgressCard.js
+++ b/app/client-app/src/components/core/ProgressCard.js
@@ -1,6 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Flex, Text, Grid, useColorMode, useTheme } from "@chakra-ui/core";
+import {
+  Flex,
+  Text,
+  Grid,
+  useColorMode,
+  useTheme,
+  Alert,
+  AlertIcon,
+} from "@chakra-ui/core";
 import { ActiveIndicator } from ".";
 import LightHeading from "./LightHeading";
 import { defaultColorMode } from "themes";
@@ -32,12 +40,14 @@ const ProgressCard = ({
       templateColumns={`${cardHeaderWidth} 1fr`}
       alignItems="center"
       p={lowProfile ? 0 : 2}
+      pl={2} // fix left padding for title alignment
       _hover={lowProfile ? null : { boxShadow: "callout", zIndex: 2 }}
     >
       <LightHeading
         p={lowProfile ? 1 : 2}
+        px={2} // fix x padding for alignment
         as="h5"
-        size={lowProfile ? "xs" : "sm"}
+        size="sm"
         textAlign="right"
       >
         {title}
@@ -45,7 +55,10 @@ const ProgressCard = ({
 
       {message ? (
         <Flex p={1}>
-          <Text>{message}</Text>
+          <Alert p={1} variant="left-accent">
+            <AlertIcon />
+            <Text>{message}</Text>
+          </Alert>
         </Flex>
       ) : (
         <Flex flexDirection="column">

--- a/app/client-app/src/components/core/ProgressCard.js
+++ b/app/client-app/src/components/core/ProgressCard.js
@@ -12,14 +12,18 @@ const ProgressCard = ({
   progressData,
   total,
   cardHeaderWidth,
+  message = null,
+  lowProfile = false,
 }) => {
   const { colorMode } = useColorMode();
   const {
     sharedStyles: { card: style },
   } = useTheme();
 
-  const missingDataCount = total - progressData.length;
-  progressData = [...progressData, ...Array(missingDataCount).fill({})];
+  const missingDataCount = !total ? 0 : total - progressData.length;
+  progressData = !missingDataCount
+    ? progressData
+    : [...progressData, ...Array(missingDataCount).fill({})];
 
   return (
     <Grid
@@ -27,29 +31,41 @@ const ProgressCard = ({
       {...style[colorMode || defaultColorMode]}
       templateColumns={`${cardHeaderWidth} 1fr`}
       alignItems="center"
-      p={2}
-      _hover={{ boxShadow: "callout", zIndex: 2 }}
+      p={lowProfile ? 0 : 2}
+      _hover={lowProfile ? null : { boxShadow: "callout", zIndex: 2 }}
     >
-      <LightHeading p={2} as="h5" size="sm" textAlign="right">
+      <LightHeading
+        p={lowProfile ? 1 : 2}
+        as="h5"
+        size={lowProfile ? "xs" : "sm"}
+        textAlign="right"
+      >
         {title}
       </LightHeading>
 
-      <Flex flexDirection="column">
-        {progressHeader && <Text>{progressHeader}</Text>}
-        <Flex alignItems="center" flexWrap="wrap">
-          {progressData.map((x, i) => (
-            <Flex key={i} m="0.1em">
-              <ActiveIndicator
-                active={x.complete}
-                tooltips={{
-                  [true]: "Complete",
-                  [false]: "Incomplete",
-                }}
-              />
-            </Flex>
-          ))}
+      {message ? (
+        <Flex p={1}>
+          <Text>{message}</Text>
         </Flex>
-      </Flex>
+      ) : (
+        <Flex flexDirection="column">
+          {progressHeader && <Text>{progressHeader}</Text>}
+          <Flex alignItems="center" flexWrap="wrap">
+            {progressData.map((x, i) => (
+              <Flex key={i} m="0.1em">
+                <ActiveIndicator
+                  p={lowProfile ? 0.5 : 2}
+                  active={x.complete}
+                  tooltips={{
+                    [true]: "Complete",
+                    [false]: "Incomplete",
+                  }}
+                />
+              </Flex>
+            ))}
+          </Flex>
+        </Flex>
+      )}
     </Grid>
   );
 };
@@ -64,7 +80,7 @@ ProgressCard.propTypes = {
       complete: PropTypes.bool,
     })
   ),
-  total: PropTypes.number.isRequired,
+  total: PropTypes.number,
 };
 
 ProgressCard.defaultProps = {

--- a/app/client-app/src/components/core/ProgressCard.stories.js
+++ b/app/client-app/src/components/core/ProgressCard.stories.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { ProgressCard } from "components/core";
 
+const title = "Page 1";
+
 const progressData = [
   { label: "1", complete: true },
   { label: "2", complete: true },
@@ -19,10 +21,31 @@ export default {
   component: ProgressCard,
 };
 
-export const Basic = () => <ProgressCard title="Question 1" total={10} />;
+export const Basic = () => <ProgressCard title={title} total={10} />;
 
 export const WithHeader = () => (
-  <ProgressCard title="Question 1" progressHeader="Participants" total={50} />
+  <ProgressCard title={title} progressHeader="Participants" total={50} />
+);
+
+export const WithMessage = () => (
+  <ProgressCard title={title} message="No progress data here" />
+);
+
+export const LowProfileBasic = () => (
+  <ProgressCard title={title} lowProfile total={10} />
+);
+
+export const LowProfileHeader = () => (
+  <ProgressCard
+    title={title}
+    lowProfile
+    progressHeader="Participants"
+    total={50}
+  />
+);
+
+export const LowProfileMessage = () => (
+  <ProgressCard title={title} message="No data" lowProfile />
 );
 
 export const WithData = () => (


### PR DESCRIPTION
Dashboard now includes all pages, not only those with responses.

- This is less confusing as Page numbers are not skipped
- Pages are called "Pages" not "Questions" now, as this is more accurate.
- Pages that do not gather responses indicate that, and are subdued in the page layout