### PR TITLE
⚡ Consistent participant results sorting

### DIFF
--- a/app/Decsys/Models/ParticipantResultsSummary.cs
+++ b/app/Decsys/Models/ParticipantResultsSummary.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Decsys.Models
@@ -10,6 +11,8 @@ namespace Decsys.Models
         public ParticipantResultsSummary(string id) => Id = id;
 
         public string Id { get; set; }
+
+        public DateTimeOffset SurveyStarted { get; set; }
 
         /// <summary>
         /// The participant's reponse to each survey question

--- a/app/Decsys/Services/ParticipantEventService.cs
+++ b/app/Decsys/Services/ParticipantEventService.cs
@@ -160,9 +160,14 @@ namespace Decsys.Services
 
         private ParticipantResultsSummary ParticipantResultsSummary(SurveyInstance instance, string participantId)
         {
+            var firstPageLoad = _events
+                .List(instance.Id, participantId, null, EventTypes.PAGE_LOAD)
+                .First();
+
             var resultsSummary = new ParticipantResultsSummary(participantId)
             {
-                Responses = new List<PageResponseSummary>()
+                Responses = new List<PageResponseSummary>(),
+                SurveyStarted = firstPageLoad.Timestamp
             };
 
             var orderEvent = FindLast(

--- a/app/client-app/src/app/pages/Dashboard.js
+++ b/app/client-app/src/app/pages/Dashboard.js
@@ -24,10 +24,17 @@ import {
 import { getComponent, getPageResponseItem } from "services/page-items";
 import { Body as SurveyPageBody } from "components/shared/SurveyPage";
 import LightHeading from "components/core/LightHeading";
-import { exportDateFormat as formatDate } from "services/date-formats";
+import {
+  dateTimeOffsetStringComparer,
+  exportDateFormat as formatDate,
+} from "services/date-formats";
 import { defaultColorMode } from "themes";
 
 const getDataByPage = (survey, results) => {
+  results.participants = results.participants.sort((a, b) =>
+    dateTimeOffsetStringComparer(a.surveyStarted, b.surveyStarted)
+  );
+
   const resultsByPage = results.participants.reduce((a, p) => {
     p.responses.forEach((r) => {
       a[r.page] = a[r.page] || {};
@@ -42,8 +49,6 @@ const getDataByPage = (survey, results) => {
       return a;
     }, {})
   );
-
-  console.log(resultsByPage, completionByPage);
 
   return {
     resultsByPage,

--- a/app/client-app/src/app/pages/Results.js
+++ b/app/client-app/src/app/pages/Results.js
@@ -5,7 +5,10 @@ import {
   getInstanceResultsSummary,
   getInstanceResultsFull,
 } from "api/survey-instances";
-import { exportDateFormat as formatDate } from "services/date-formats";
+import {
+  dateTimeOffsetStringComparer,
+  exportDateFormat as formatDate,
+} from "services/date-formats";
 import { getResultsCsvData, downloadFile } from "services/export";
 import download from "downloadjs";
 import LightHeading from "components/core/LightHeading";
@@ -388,6 +391,9 @@ const Results = ({ id }) => {
         const { data } = await getInstanceResultsSummary(
           currentInstance.survey.id,
           currentInstance.id
+        );
+        data.participants = data.participants.sort((a, b) =>
+          dateTimeOffsetStringComparer(a.surveyStarted, b.surveyStarted)
         );
         setResults(data);
       })();

--- a/app/client-app/src/services/date-formats.js
+++ b/app/client-app/src/services/date-formats.js
@@ -16,3 +16,12 @@ export const exportDateFormat = (date) => {
   const [time, tz] = timeWithZone.split(" ");
   return { date: formattedDate, time, tz, flat: formattedDateTime };
 };
+
+export const dateTimeOffsetStringComparer = (a, b) => {
+  const ad = new Date(a).toISOString();
+  const bd = new Date(b).toISOString();
+
+  if (ad === bd) return 0;
+  if (ad > bd) return 1;
+  return -1;
+};


### PR DESCRIPTION
Both the Dashboard and Results views weren't particular about sorting participants, in the case of the Dashboard even changing the order from one Page to another.

Both now sort participants in ascending order based on when the Participant started the survey (i.e. first loaded a page).