### PR TITLE
🎉App 2.0.0-beta.9

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,7 @@ plugins:
 pnpMode: loose
 
 yarnPath: .yarn/releases/yarn-sources.cjs
+
+changesetBaseRefs:
+  - "main"
+  - "origin/main"

--- a/app/Decsys/Decsys.csproj
+++ b/app/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>2.0.0-beta.8</Version>
+    <Version>2.0.0-beta.9</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/app/Decsys/Models/ParticipantResultsSummary.cs
+++ b/app/Decsys/Models/ParticipantResultsSummary.cs
@@ -12,7 +12,7 @@ namespace Decsys.Models
 
         public string Id { get; set; }
 
-        public DateTimeOffset SurveyStarted { get; set; }
+        public DateTimeOffset? SurveyStarted { get; set; }
 
         /// <summary>
         /// The participant's reponse to each survey question

--- a/app/Decsys/Services/ParticipantEventService.cs
+++ b/app/Decsys/Services/ParticipantEventService.cs
@@ -162,12 +162,12 @@ namespace Decsys.Services
         {
             var firstPageLoad = _events
                 .List(instance.Id, participantId, null, EventTypes.PAGE_LOAD)
-                .First();
+                .FirstOrDefault();
 
             var resultsSummary = new ParticipantResultsSummary(participantId)
             {
                 Responses = new List<PageResponseSummary>(),
-                SurveyStarted = firstPageLoad.Timestamp
+                SurveyStarted = firstPageLoad?.Timestamp
             };
 
             var orderEvent = FindLast(

--- a/app/client-app/package.json
+++ b/app/client-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "private": true,
   "scripts": {
     "start": "craco start",

--- a/app/client-app/src/app/pages/Results.js
+++ b/app/client-app/src/app/pages/Results.js
@@ -210,7 +210,7 @@ const ResultsTable = ({ columns, data, page, participant }) => {
         <thead>
           {headerGroups.map((group) => (
             <tr {...group.getHeaderGroupProps()}>
-              {group.headers.map((column) => {
+              {group.headers.map((column, i) => {
                 const width =
                   {
                     Page: "100px",
@@ -218,14 +218,21 @@ const ResultsTable = ({ columns, data, page, participant }) => {
                     "Page Loaded (UTC)": "200px",
                     "Recorded (UTC)": "200px",
                   }[column.Header] ?? "auto";
-                return <Header column={column} colors={colors} width={width} />;
+                return (
+                  <Header
+                    key={i}
+                    column={column}
+                    colors={colors}
+                    width={width}
+                  />
+                );
               })}
             </tr>
           ))}
         </thead>
         <tbody {...getTableBodyProps()}>
-          {rows.map((row) => (
-            <Row row={row} colors={colors} prepareRow={prepareRow} />
+          {rows.map((row, i) => (
+            <Row key={i} row={row} colors={colors} prepareRow={prepareRow} />
           ))}
         </tbody>
       </table>
@@ -295,8 +302,8 @@ const Row = memo(({ row, colors, prepareRow }) => {
       }}
       {...row.getRowProps()}
     >
-      {row.cells.map((cell) => (
-        <Cell cell={cell} />
+      {row.cells.map((cell, i) => (
+        <Cell key={i} cell={cell} />
       ))}
     </tr>
   );


### PR DESCRIPTION
## Client App 2.0.0-beta.9
- `ResultsTable` was missing key props in a few child lists

## API App 2.0.0-beta.9
- Generating Participant Results Summaries used to assume a participant would always have at least 1 `PAGE_LOAD` event. It no longer assumes this now that it has proven to be false.

## Repo
- Configured yarn to do version checks against `main`, not `master`