### PR TITLE
🐛 Choose one index bug

### DIFF
--- a/response-items/src/choose-one/ResponseItem.stories.js
+++ b/response-items/src/choose-one/ResponseItem.stories.js
@@ -67,4 +67,21 @@ export const RadioList = () => {
   return <ResponseItem dropDown={false} {...props()} />;
 };
 
+export const OptionValueNotPropOrderBased = () => (
+  <ResponseItem
+    _context={_context}
+    dropDown={false}
+    option8=""
+    option7=""
+    option6=""
+    option0="All of the time"
+    option1="Most of the time"
+    option2="A good bit of the time"
+    option9=""
+    option3="Some of the time"
+    option4="A little bit of the time"
+    option5="None of the time"
+  />
+);
+
 export const MetadataIcon = () => <Icon width="24px" />;

--- a/response-items/src/choose-one/ResponseItem.stories.js
+++ b/response-items/src/choose-one/ResponseItem.stories.js
@@ -77,10 +77,10 @@ export const OptionValueNotPropOrderBased = () => (
     option0="All of the time"
     option1="Most of the time"
     option2="A good bit of the time"
-    option9=""
+    option9="None of the time"
     option3="Some of the time"
     option4="A little bit of the time"
-    option5="None of the time"
+    option5=""
   />
 );
 

--- a/response-items/src/choose-one/utils/option-params.js
+++ b/response-items/src/choose-one/utils/option-params.js
@@ -31,6 +31,6 @@ export const filterOptions = (props) => {
 
   // - one to revalue them based on the new ordered subset of configured options: [0,5,9] = [0,1,2]
   return includeOptions
-    .sort(({ value: a }, { value: b }) => a > b)
+    .sort(({ value: a }, { value: b }) => a - b)
     .map((x, i) => ({ ...x, value: i }));
 };

--- a/response-items/src/choose-one/utils/option-params.js
+++ b/response-items/src/choose-one/utils/option-params.js
@@ -3,18 +3,34 @@
  * options.
  * @param {*} options
  */
-export const filterOptions = (options) => {
-  return Object.entries(options).reduce((acc, [key, val], idx) => {
-    if (key.includes("option") && !!val) {
-      return [
-        ...acc,
-        {
-          label: val,
-          value: idx,
-        },
-      ];
-    }
+export const filterOptions = (props) => {
+  // to maintain contiguous values despite possible non contiguous option config
+  // (e.g. option5, option0, option9 = values [1,0,2] reordered to [0,1,2], not [5,0,9] or [0,5,9])
+  // we require 2 passes
 
-    return acc;
-  }, []);
+  // - one to evaluate the options we care about,
+  // and their original numeric value (from which we can order them correctly):
+  // e.g. option1(empty), option9, option0, option5 = [9,0,5]
+  const includeOptions = Object.entries(props).reduce(
+    (options, [key, label]) => {
+      const value = parseInt(key.replace("option", ""));
+      if (!isNaN(value) && !!label) {
+        return [
+          ...options,
+          {
+            label,
+            value,
+          },
+        ];
+      }
+
+      return options;
+    },
+    []
+  );
+
+  // - one to revalue them based on the new ordered subset of configured options: [0,5,9] = [0,1,2]
+  return includeOptions
+    .sort(({ value: a }, { value: b }) => a > b)
+    .map((x, i) => ({ ...x, value: i }));
 };


### PR DESCRIPTION
The way the Choose One response filters its props to obtain its response options was resulting in incorrect response index values in some circumstances. It assumed prop order would always be numerically ascending, which has turned out not to be guaranteed.