### PR TITLE
Reset Scrolling when navigating between survey pages

### DIFF
--- a/app/client-app/src/app/pages/Preview.js
+++ b/app/client-app/src/app/pages/Preview.js
@@ -26,17 +26,28 @@ const Preview = ({ id, location }) => {
   // with regards to page order, and position
   // TODO: consider adding randomisation
   const [page, setPage] = useState(0);
+  const [isBusy, setIsBusy] = useState();
   const [lastPage, setLastPage] = useState(false);
   useEffect(() => setLastPage(page === pages.length - 1), [page, pages.length]);
   const confirmRedirectModal = useDisclosure();
 
-  const handleClick = () => {
+  const handleClick = async () => {
+    // you'd think busy state in preview wouldn't be worth it
+
+    setIsBusy(true);
+
+    // but in practice it resets scrolling between different page content ;)
+    // as long as it takes a non "zero" amount of time
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     if (lastPage) {
       if (settings?.CompletionUrl) confirmRedirectModal.onOpen();
       else return navigateBack(location);
     } else {
       setPage(page + 1);
     }
+
+    setIsBusy(false);
   };
 
   return (
@@ -46,6 +57,7 @@ const Preview = ({ id, location }) => {
         page={pages[page]}
         lastPage={lastPage}
         handleNextClick={handleClick}
+        isBusy={isBusy}
       />
       <ConfirmRedirectModal
         modalState={confirmRedirectModal}


### PR DESCRIPTION
This was half fixed by virtue of the new progress system, due to the "isBusy" state on pages when requesting navigation to a different page.

That state causes a remount of SurveyPage, which would therefore no longer retain its previous scroll position.

However, Preview mode manages its own progress state, so doesn't remount as a result of pinging the server.

So have added a dummy busy state between pages in preview to achieve the same result, and more closely behave like a real survey