### PR TITLE
Images in exports now import correctly

### DIFF
--- a/app/Decsys/Services/ExportService.cs
+++ b/app/Decsys/Services/ExportService.cs
@@ -1,7 +1,10 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+
 using Decsys.Services.Contracts;
+
 using Newtonsoft.Json;
+
 using UoN.ZipBuilder;
 
 namespace Decsys.Services
@@ -40,8 +43,8 @@ namespace Decsys.Services
                     "structure.json");
 
             // if this survey has any images uploaded, add them
-            foreach(var (filename, bytes) in await _images.ListSurveyImages(surveyId))
-                zipBuilder = zipBuilder.AddBytes(bytes, filename);
+            foreach (var (filename, bytes) in await _images.ListSurveyImages(surveyId))
+                zipBuilder = zipBuilder.AddBytes(bytes, $"images/{filename}");
 
             return zipBuilder;
         }

--- a/app/Decsys/Services/ImageService/LocalFileImageService.cs
+++ b/app/Decsys/Services/ImageService/LocalFileImageService.cs
@@ -127,14 +127,14 @@ namespace Decsys.Services
         public async Task<byte[]> GetImage(int surveyId, Guid componentId, string extension)
             => await GetImage(surveyId, GetImageFilename(componentId, extension));
 
-
         public async Task<List<(string filename, byte[] bytes)>> ListSurveyImages(int surveyId)
         {
             List<(string filename, byte[] bytes)> images = new();
             var files = await Enumerate(surveyId);
 
-            foreach (var filename in files)
+            foreach (var filePath in files)
             {
+                var filename = Path.GetFileName(filePath);
                 var bytes = await File.ReadAllBytesAsync(
                     Path.Combine(SurveyImagesPath(surveyId), filename));
                 images.Add((filename, bytes));


### PR DESCRIPTION
Exports changed (and behaved differently in Hosted and Workshop mode) so imports no longer worked.

But the existing imports way was desirable, so exports have been fixed to behave consistently in the way imports expect.

This will not allow importing images from earlier broken exports, but new exports will import correctly.