### PR TITLE
Various fixes

### DIFF
--- a/app/client-app/src/app/pages/Dashboard/DetailsModalBody.js
+++ b/app/client-app/src/app/pages/Dashboard/DetailsModalBody.js
@@ -77,7 +77,7 @@ const DetailsModalBody = ({ surveyId, page, results, completion }) => {
     return (
       <Alert status="warning">
         <AlertIcon />
-        There is no data for this question yet.
+        There are no data for this question yet.
       </Alert>
     );
   }

--- a/app/client-app/src/app/pages/Dashboard/index.js
+++ b/app/client-app/src/app/pages/Dashboard/index.js
@@ -106,7 +106,7 @@ const Dashboard = ({ combinedId }) => {
 
               let noProgressMessage; // If there's no progress data, display a relevant message
               if (!isResponsePage)
-                noProgressMessage = "This page doesn't gather reponses.";
+                noProgressMessage = "This page doesn't gather responses.";
               if (!Object.keys(completionData).length)
                 noProgressMessage =
                   "The survey doesn't have any participants yet.";

--- a/app/client-app/src/app/pages/Editor/actions/pageListActions.js
+++ b/app/client-app/src/app/pages/Editor/actions/pageListActions.js
@@ -10,7 +10,7 @@ import { setSurveyPageItemOrder } from "api/page-items";
 import produce from "immer";
 import { v4 as uuid } from "uuid";
 
-export default (id, mutate, selectedPageItem, setSelectedPageItem) => ({
+const actions = (id, mutate, selectedPageItem, setSelectedPageItem) => ({
   addPage: async () => {
     const tempId = uuid();
     mutate(
@@ -103,3 +103,5 @@ export default (id, mutate, selectedPageItem, setSelectedPageItem) => ({
   },
   mutate,
 });
+
+export default actions;

--- a/app/client-app/src/app/pages/Editor/components/PageItemEditor/ParamsEditor.js
+++ b/app/client-app/src/app/pages/Editor/components/PageItemEditor/ParamsEditor.js
@@ -9,12 +9,16 @@ const ParamsEditor = ({ component, params, handleParamChange }) => {
     const p = component.params[key];
     if (!p) continue;
     list.push([
-      <Text key={`${key}-label`} textAlign="right" fontWeight="bold">
+      <Text
+        key={`${component.id}-${key}-label`}
+        textAlign="right"
+        fontWeight="bold"
+      >
         {p.label}
       </Text>,
       <Param
-        key={`${key}-value`}
-        value={params[key] || p.defaultValue}
+        key={`${component.id}-${key}-value`}
+        value={params[key] || (p.defaultValue ?? "")}
         type={p.type}
         paramKey={key}
         oneOf={p.oneOf}

--- a/app/client-app/src/app/pages/Surveys/components/ExternalDetailsModal.js
+++ b/app/client-app/src/app/pages/Surveys/components/ExternalDetailsModal.js
@@ -4,18 +4,26 @@ import {
   AlertDescription,
   AlertIcon,
   AlertTitle,
+  Flex,
   Stack,
   Text,
 } from "@chakra-ui/react";
 import { capitalise } from "services/strings";
 import LightHeading from "components/core/LightHeading";
+import { CopyableTextPanel } from "components/core/CopyableTextPanel";
+import ReactMarkdown from "react-markdown";
+import "github-markdown-css";
 
-const Definition = ({ term, definition }) => (
-  <>
-    <Text fontWeight="bold">{term}</Text>
-    <Text>{definition}</Text>
-  </>
-);
+const Definition = ({ term, definition, isInline }) => {
+  const render = (
+    <>
+      <Text fontWeight="bold">{term}</Text>
+      <Text pl={2}>{definition}</Text>
+    </>
+  );
+
+  return isInline ? <Flex>{render}</Flex> : render;
+};
 
 const ExternalDetailsModal = ({
   modalState,
@@ -25,6 +33,13 @@ const ExternalDetailsModal = ({
   hasInvalidExternalLink,
 }) => {
   if (!type) return null;
+
+  // TODO: will this ever differ by survey type?
+  const externalSurveyUrl = `${window.location.origin.replace(
+    "localhost",
+    "<ip-address>"
+  )}/survey`;
+
   return (
     <StandardModal
       size="xl"
@@ -34,7 +49,24 @@ const ExternalDetailsModal = ({
     >
       <Stack w="100%" spacing={2} mb={3}>
         <Stack w="100%" pl={2}>
-          <Definition term="Survey Name" definition={name} />
+          <CopyableTextPanel label="Survey Name" value={name} />
+
+          {externalSurveyUrl?.includes("<ip-address>") && (
+            <Alert status="warning">
+              <AlertIcon />
+
+              <Text as="div" className="markdown-body">
+                <ReactMarkdown
+                  source={`
+Since you're running in **Workshop Mode**, you'll need to provide
+an ip address where your machine can access DECSYS, such as
+\`127.0.0.1\`
+            `}
+                />
+              </Text>
+            </Alert>
+          )}
+          <CopyableTextPanel label="Survey URL" value={externalSurveyUrl} />
         </Stack>
 
         <LightHeading size="md">{capitalise(type)} Settings</LightHeading>
@@ -52,7 +84,7 @@ const ExternalDetailsModal = ({
             </Alert>
           )}
           {Object.keys(settings).map((k) => (
-            <Definition key={k} term={k} definition={settings[k]} />
+            <CopyableTextPanel key={k} label={k} value={settings[k]} />
           ))}
         </Stack>
       </Stack>

--- a/app/client-app/src/components/core/CopyableTextPanel.js
+++ b/app/client-app/src/components/core/CopyableTextPanel.js
@@ -9,7 +9,12 @@ import {
 import { useState } from "react";
 import { FaCheck, FaCopy } from "react-icons/fa";
 
-export const CopyableTextPanel = ({ label, value }) => {
+export const CopyableTextPanel = ({
+  label,
+  value,
+  hideCopyButton,
+  buttonScheme = "gray",
+}) => {
   const [copyButton, setCopyButton] = useState({
     leftIcon: <FaCopy />,
     children: "Copy",
@@ -20,6 +25,15 @@ export const CopyableTextPanel = ({ label, value }) => {
       leftIcon: <FaCheck />,
       children: "Copied!",
     });
+
+    setTimeout(
+      () =>
+        setCopyButton({
+          leftIcon: <FaCopy />,
+          children: "Copy",
+        }),
+      2000
+    );
   };
 
   return (
@@ -30,15 +44,18 @@ export const CopyableTextPanel = ({ label, value }) => {
         </InputLeftAddon>
       )}
       <Input variant="filled" readOnly value={value} />
-      <InputRightElement w="5rem">
-        <Button
-          colorScheme="blue"
-          size="sm"
-          h="1.75rem"
-          {...copyButton}
-          onClick={onCopyClick}
-        />
-      </InputRightElement>
+      {!hideCopyButton && (
+        <InputRightElement w="5rem">
+          <Button
+            colorScheme={buttonScheme}
+            size="sm"
+            h="1.75rem"
+            {...copyButton}
+            transition="linear .1s content"
+            onClick={onCopyClick}
+          />
+        </InputRightElement>
+      )}
     </InputGroup>
   );
 };

--- a/app/client-app/src/components/core/CopyableTextPanel.js
+++ b/app/client-app/src/components/core/CopyableTextPanel.js
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Input,
+  InputGroup,
+  InputLeftAddon,
+  InputRightElement,
+  Text,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { FaCheck, FaCopy } from "react-icons/fa";
+
+export const CopyableTextPanel = ({ label, value }) => {
+  const [copyButton, setCopyButton] = useState({
+    leftIcon: <FaCopy />,
+    children: "Copy",
+  });
+  const onCopyClick = () => {
+    navigator.clipboard.writeText(value);
+    setCopyButton({
+      leftIcon: <FaCheck />,
+      children: "Copied!",
+    });
+  };
+
+  return (
+    <InputGroup>
+      {label && (
+        <InputLeftAddon>
+          <Text fontWeight="bold">{label}</Text>
+        </InputLeftAddon>
+      )}
+      <Input variant="filled" readOnly value={value} />
+      <InputRightElement w="5rem">
+        <Button
+          colorScheme="blue"
+          size="sm"
+          h="1.75rem"
+          {...copyButton}
+          onClick={onCopyClick}
+        />
+      </InputRightElement>
+    </InputGroup>
+  );
+};

--- a/app/client-app/src/components/page-items/Heading.js
+++ b/app/client-app/src/components/page-items/Heading.js
@@ -4,8 +4,6 @@ import LightHeading from "components/core/LightHeading";
 const PageHeading = ({ text, xMargin, color, variant, ...p }) => {
   const size = { h1: "2xl", h2: "xl", h3: "lg", h4: "md", h5: "sm" }[variant];
 
-  console.log(xMargin);
-
   return (
     // we set color in standard CSS,
     // so that simple CSS color names work e.g. "red"

--- a/app/client-app/src/components/page-items/Heading.js
+++ b/app/client-app/src/components/page-items/Heading.js
@@ -4,6 +4,8 @@ import LightHeading from "components/core/LightHeading";
 const PageHeading = ({ text, xMargin, color, variant, ...p }) => {
   const size = { h1: "2xl", h2: "xl", h3: "lg", h4: "md", h5: "sm" }[variant];
 
+  console.log(xMargin);
+
   return (
     // we set color in standard CSS,
     // so that simple CSS color names work e.g. "red"
@@ -12,9 +14,11 @@ const PageHeading = ({ text, xMargin, color, variant, ...p }) => {
       as={variant}
       size={size}
       {...p}
-      mr={p.textAlign === "right" ? `${xMargin}%` : 0}
-      ml={p.textAlign === "left" ? `${xMargin}%` : 0}
-      style={{ color }}
+      style={{
+        color,
+        marginLeft: p.textAlign === "left" ? `${xMargin}%` : 0,
+        marginRight: p.textAlign === "right" ? `${xMargin}%` : 0,
+      }}
     >
       {text}
     </LightHeading>

--- a/app/client-app/src/components/page-items/Paragraph.PreviewEditor.js
+++ b/app/client-app/src/components/page-items/Paragraph.PreviewEditor.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Icon,
   Textarea,
@@ -12,6 +12,8 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { FaInfoCircle, FaExternalLinkAlt } from "react-icons/fa";
+import { useDerivedState } from "hooks/useDerivedState";
+import useDeferredAction from "hooks/useDeferredAction";
 
 const PageParagraphEditor = ({
   _context: { handleParamChange },
@@ -20,18 +22,15 @@ const PageParagraphEditor = ({
 }) => {
   const [gfmVisible, setGfmVisible] = useState(true);
 
-  const [timer, setTimer] = useState();
-
-  const [text, setText] = useState(params.text); // we use local state so updates work without delay
-  useEffect(() => setText(params.text), [params]); // but still ensure update when new name props come in
+  const [text, setText] = useDerivedState(params.text); // we use local state so updates work without delay
+  const deferredSave = useDeferredAction(
+    (value) => handleParamChange("text", value),
+    1000
+  );
 
   const handleChange = (e) => {
-    setText(e.target.value); //update local state
-    e.persist(); // tell React we want the event to have a longer lifetime than this scope
-    //delay, then fire the onChange passed in
-    clearTimeout(timer); // reset the delay timer every change
-    setTimer(setTimeout(() => handleParamChange("text", e.target.value), 1000));
-    // TODO: read about debouncing
+    setText(e.target.value);
+    deferredSave(e.target.value);
   };
   return (
     <Tabs onChange={(i) => setGfmVisible(!i)}>

--- a/app/client-app/src/components/shared/CreateSurveyModal.js
+++ b/app/client-app/src/components/shared/CreateSurveyModal.js
@@ -76,7 +76,11 @@ an ip address where your machine can access DECSYS, such as
               </Text>
             </Alert>
           )}
-          <CopyableTextPanel label="Survey URL:" value={surveyUrl} />
+          <CopyableTextPanel
+            buttonScheme="blue"
+            label="Survey URL"
+            value={surveyUrl}
+          />
         </Stack>
 
         <Text pb={2} as="div" className="markdown-body">

--- a/app/client-app/src/components/shared/CreateSurveyModal.js
+++ b/app/client-app/src/components/shared/CreateSurveyModal.js
@@ -236,7 +236,7 @@ const CreateSurveyModal = ({
                     `${window.location.origin.replace(
                       "localhost",
                       "<ip-address>"
-                    )}/ext`
+                    )}/survey`
                   )}
                 />
                 <Field name="prolificStudyId">

--- a/app/client-app/src/components/shared/CreateSurveyModal.js
+++ b/app/client-app/src/components/shared/CreateSurveyModal.js
@@ -24,6 +24,7 @@ import gfm from "remark-gfm";
 import "github-markdown-css";
 import { FaChevronDown, FaChevronRight } from "react-icons/fa";
 import { object, string } from "yup";
+import { CopyableTextPanel } from "components/core/CopyableTextPanel";
 
 // There are a number of ways to create a survey: Blank, Import, Duplicate etc.
 // But they also all require some common follow up information
@@ -42,14 +43,13 @@ const validationSchema = object().shape({
   }),
 });
 
-const SetupGuide = ({ markdown }) => {
+const SetupGuide = ({ markdown, surveyUrl }) => {
   const { isOpen, onToggle } = useDisclosure();
 
   return (
     <Stack
       bg="gray.200"
       borderRadius={5}
-      onClick={onToggle}
       alignItems="center"
       spacing={0}
       boxShadow=""
@@ -60,6 +60,25 @@ const SetupGuide = ({ markdown }) => {
       </Flex>
 
       <Collapse in={isOpen} animateOpacity>
+        <Stack p={2}>
+          {surveyUrl?.includes("<ip-address>") && (
+            <Alert status="warning">
+              <AlertIcon />
+
+              <Text as="div" className="markdown-body">
+                <ReactMarkdown
+                  source={`
+Since you're running in **Workshop Mode**, you'll need to provide
+an ip address where your machine can access DECSYS, such as
+\`127.0.0.1\`
+            `}
+                />
+              </Text>
+            </Alert>
+          )}
+          <CopyableTextPanel label="Survey URL:" value={surveyUrl} />
+        </Stack>
+
         <Text pb={2} as="div" className="markdown-body">
           <ReactMarkdown
             plugins={[gfm]}
@@ -72,10 +91,9 @@ const SetupGuide = ({ markdown }) => {
   );
 };
 
-const prolificInstructions = (surveyUrl) => `
+const prolificInstructions = `
 1. Create your study in [Prolific]("https://prolific.co")
-1. Provide the following survey url:
-    - \`${surveyUrl}\`
+1. Provide the **Survey URL** (above)
 1. When asked **"How do you want to record Prolific IDs?"**
     - Choose **"I'll use URL parameters"**
     - You can leave the default settings
@@ -132,6 +150,11 @@ const CreateSurveyModal = ({
     actions.setSubmitting(false);
     actions.resetForm();
   };
+
+  const externalSurveyUrl = `${window.location.origin.replace(
+    "localhost",
+    "<ip-address>"
+  )}/survey`;
 
   return (
     <Formik
@@ -232,12 +255,8 @@ const CreateSurveyModal = ({
 
               <Stack hidden={values.type !== "prolific"}>
                 <SetupGuide
-                  markdown={prolificInstructions(
-                    `${window.location.origin.replace(
-                      "localhost",
-                      "<ip-address>"
-                    )}/survey`
-                  )}
+                  surveyUrl={externalSurveyUrl}
+                  markdown={prolificInstructions}
                 />
                 <Field name="prolificStudyId">
                   {(rp) => (

--- a/app/client-app/src/components/shared/SortPanel/hooks.js
+++ b/app/client-app/src/components/shared/SortPanel/hooks.js
@@ -1,8 +1,16 @@
 import { useState, useEffect } from "react";
 import { getSortedLookup, getFilteredLookup } from "./helpers";
 
-export const useSortingAndFiltering = surveys => {
-  const [sorting, setSorting] = useState({ key: "name", name: true });
+const storageKey = "surveys.sorting";
+
+export const useSortingAndFiltering = (surveys) => {
+  const [sorting, setSorting] = useState(
+    JSON.parse(localStorage.getItem(storageKey)) || {
+      key: "name",
+      name: true,
+    }
+  );
+
   const [sortedSurveys, setSortedSurveys] = useState([]);
   const [filter, setFilter] = useState("");
   const [filteredSurveys, setFilteredSurveys] = useState([]);
@@ -12,6 +20,8 @@ export const useSortingAndFiltering = surveys => {
     setSortedSurveys(
       getSortedLookup(surveys, sorting.key, sorting[sorting.key])
     );
+    // also save the new sort for next time
+    localStorage.setItem(storageKey, JSON.stringify(sorting));
   }, [surveys, sorting]);
 
   // update the filtered list appropriately
@@ -24,6 +34,6 @@ export const useSortingAndFiltering = surveys => {
     setSorting,
     filter,
     setFilter,
-    surveyList: filteredSurveys
+    surveyList: filteredSurveys,
   };
 };


### PR DESCRIPTION
This is a catch all merge for a number of small fixes: typos and other bugbears affecting admins only.

- Prolific Survey URL is now correctly provided in the setup guide
- Some clarity on use of that URL has been provided, particularly when accessing from `localhost`
- External Survey URL is copyable :)
- The External Survey Details modal includes the External Survey URL
- Dashboard typo fixes
- Paragraph Page Item debouncing on autosave shouldn't interfere with typing anymore
- Heading Page Item xMargin was broken by a chakra update, so CSS specificity has been adjusted to fix this.
- Changing between Page Items of the same type now loads the correct params
- The Surveys List now remembers sort order