### PR TITLE
dashboard progress cards now show the page's response item

### DIFF
--- a/app/client-app/src/app/pages/Dashboard/index.js
+++ b/app/client-app/src/app/pages/Dashboard/index.js
@@ -9,14 +9,24 @@ import {
 import { decode } from "services/instance-id";
 import { useSurvey } from "api/surveys";
 import { useSurveyInstanceResultsSummary } from "api/survey-instances";
-import { Alert, AlertIcon, Flex, Stack, useDisclosure } from "@chakra-ui/react";
+import {
+  Alert,
+  AlertIcon,
+  Badge,
+  Flex,
+  Icon,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
 import LightHeading from "components/core/LightHeading";
 import {
   dateTimeOffsetStringComparer,
   exportDateFormat as formatDate,
 } from "services/date-formats";
 import DetailsModalBody from "./DetailsModalBody";
-import { getPageResponseItem } from "services/page-items";
+import { getPageResponseItem, getComponent } from "services/page-items";
+import { FaQuestion } from "react-icons/fa";
 
 const getDataByPage = (survey, results) => {
   // sort participants consistently,
@@ -101,7 +111,8 @@ const Dashboard = ({ combinedId }) => {
         {surveyHasPages && !isLoading && (
           <Stack boxShadow="callout" spacing={0}>
             {survey.pages.map((p, i) => {
-              const isResponsePage = !!getPageResponseItem(p.components);
+              const responseItem = getPageResponseItem(p.components);
+              const isResponsePage = !!responseItem;
               const completionData = completionByPage[i]; // 0-indexed array, matching `survey.pages`
 
               let noProgressMessage; // If there's no progress data, display a relevant message
@@ -114,6 +125,21 @@ const Dashboard = ({ combinedId }) => {
                 <ProgressCard
                   key={i}
                   title={`Page ${i + 1}`}
+                  progressHeader={
+                    isResponsePage && (
+                      <Badge p={1}>
+                        <Stack direction="row" align="center">
+                          <Icon
+                            as={
+                              getComponent(responseItem.type)?.icon ||
+                              FaQuestion
+                            }
+                          />
+                          <Text>{responseItem.type}</Text>
+                        </Stack>
+                      </Badge>
+                    )
+                  }
                   cardHeaderWidth="100px"
                   total={results.participants.length}
                   progressData={

--- a/app/client-app/src/components/core/ProgressCard.js
+++ b/app/client-app/src/components/core/ProgressCard.js
@@ -69,7 +69,7 @@ const ProgressCard = ({
         </Flex>
       ) : (
         <Flex flexDirection="column">
-          {progressHeader && <Text>{progressHeader}</Text>}
+          {progressHeader && progressHeader}
           <Flex alignItems="center" flexWrap="wrap">
             {progressData.map((x, i) => {
               // simple check if progress has a value or not
@@ -104,7 +104,7 @@ const ProgressCard = ({
 ProgressCard.propTypes = {
   title: PropTypes.string.isRequired,
   onClick: PropTypes.func,
-  progressHeader: PropTypes.string,
+  progressHeader: PropTypes.node,
   progressData: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,

--- a/app/client-app/src/components/core/ProgressCard.stories.js
+++ b/app/client-app/src/components/core/ProgressCard.stories.js
@@ -3,22 +3,22 @@ import { ProgressCard } from "components/core";
 const title = "Page 1";
 
 const progressData = [
-  { label: "1", complete: true },
-  { label: "2", complete: true },
-  { label: "3", complete: true },
-  { label: "4", complete: true },
-  { label: "5", complete: false },
-  { label: "6", complete: false },
-  { label: "7", complete: true },
-  { label: "8", complete: true },
-  { label: "9", complete: true },
-  { label: "10", complete: true },
+  { label: "1", progress: true },
+  { label: "2", progress: true },
+  { label: "3", progress: true },
+  { label: "4", progress: true },
+  { label: "5", progress: false },
+  { label: "6", progress: false },
+  { label: "7", progress: true },
+  { label: "8", progress: true },
+  { label: "9", progress: true },
+  { label: "10", progress: true },
 ];
-
-export default {
+const story = {
   title: "Core UI/ProgressCard",
   component: ProgressCard,
 };
+export default story;
 
 export const Basic = () => <ProgressCard title={title} total={10} />;
 
@@ -51,18 +51,19 @@ export const WithData = () => (
   <ProgressCard
     title="Question 1"
     progressHeader="Participants"
-    progressData={progressData.map(({ complete }) => ({
-      complete,
+    progressData={progressData.map(({ progress }) => ({
+      progress,
     }))}
     total={10}
   />
 );
 
-export const WithLabelledData = () => (
-  <ProgressCard
-    title="Question 1"
-    progressHeader="Participants"
-    progressData={progressData}
-    total={20}
-  />
-);
+// TODO: labelled data isn't a feature of ProgressCard currently
+// export const WithLabelledData = () => (
+//   <ProgressCard
+//     title="Question 1"
+//     progressHeader="Participants"
+//     progressData={progressData}
+//     total={20}
+//   />
+// );

--- a/app/client-app/src/components/core/StateIndicator.js
+++ b/app/client-app/src/components/core/StateIndicator.js
@@ -71,7 +71,7 @@ StateIndicator.propTypes = {
   state: PropTypes.shape({
     color: PropTypes.string.isRequired,
     label: PropTypes.string,
-    icon: PropTypes.node,
+    icon: PropTypes.elementType,
   }),
 };
 

--- a/app/client-app/src/components/core/StateIndicator.stories.js
+++ b/app/client-app/src/components/core/StateIndicator.stories.js
@@ -1,10 +1,11 @@
-import { FaCheck, FaEllipsisH, FaTimes } from "react-icons/fa";
+import { FaEllipsisH } from "react-icons/fa";
 import { StateIndicator, statePresets } from "./StateIndicator";
 
-export default {
+const story = {
   title: "Core UI/StateIndicator",
   component: StateIndicator,
 };
+export default story;
 
 export const Incomplete = () => (
   <StateIndicator state={statePresets.inactive} />


### PR DESCRIPTION
For pages which gather data (i.e. have a response item), the response item type is now displayed on the progress card, so you don't need to open the page's details to discover the response type.

A side effect of this is that progress cards support rich (any React node) headers, not just text.