### PR TITLE
🐛 ParamsEditor number params no longer save as strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,8 @@ PublishScripts/
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
+# also allow the repo root packages folder, which contains source for npm packages
+!packages/*
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/[Pp]ackages/repositories.config
 # NuGet v3's project.json files produces more ignorable files

--- a/app/Decsys/Decsys.csproj
+++ b/app/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<Version>2.1.5</Version>
+		<Version>2.1.6</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/app/client-app/package.json
+++ b/app/client-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-app",
-  "version": "2.1.2",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "start": "craco start",

--- a/app/client-app/src/app/pages/Editor/components/PageItemEditor/Param.js
+++ b/app/client-app/src/app/pages/Editor/components/PageItemEditor/Param.js
@@ -27,7 +27,10 @@ const useDeferredChangeHandler = (paramKey, init, onChange) => {
     let inputValue;
     switch (typeof e) {
       case "string":
-        inputValue = e;
+        // make sure we convert back to a number, though!
+        // else items may receive strings they weren't expecting, and do invalid math!
+        const n = parseFloat(e);
+        inputValue = isNaN(n) ? init : n;
         break;
       case "object":
         inputValue = e.target.value;

--- a/app/client-app/src/components/ErrorBoundary.js
+++ b/app/client-app/src/components/ErrorBoundary.js
@@ -1,5 +1,6 @@
 import { Location } from "@reach/router";
-import React from "react";
+import React, { cloneElement } from "react";
+import { isEqual } from "lodash-es";
 
 // Error boundaries currently have to be classes.
 
@@ -46,6 +47,11 @@ class DefaultErrorBoundary extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    if (this.props.resetOnPropChanges && !isEqual(prevProps, this.props)) {
+      this.setState({
+        hasError: false,
+      });
+    }
     if (prevProps.location.key !== this.props.location.key) {
       this.setState({
         hasError: false,
@@ -55,7 +61,9 @@ class DefaultErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return this.props.fallback;
+      return cloneElement(this.props.fallback, {
+        __BoundaryError: this.state.error,
+      });
     }
     return this.props.children;
   }

--- a/app/client-app/src/components/shared/PageItemRender.js
+++ b/app/client-app/src/components/shared/PageItemRender.js
@@ -22,7 +22,7 @@ const PageItemRenderer = ({ _context, component, params }) => {
   // to be fair, such a change is probably more in the editor/backend than here when rendering;
   // the behaviour in ensureParamTypes is probably correct
 
-  // Apply defaults for usnet params, and coerce types and validate any set params
+  // Apply defaults for unset params, and coerce types and validate any set params
   const paramValues = ensureParamTypes(component.params, params);
 
   // TODO: manage passing results here too, when the platform does that again

--- a/app/client-app/src/components/shared/PageItemRender.js
+++ b/app/client-app/src/components/shared/PageItemRender.js
@@ -19,8 +19,10 @@ const PageItemRenderer = ({ _context, component, params }) => {
 
   // TODO: change defaults behaviour.
   // Empty params reverting to defaults is annoying UX and sometimes prevents intentionally empty params
-  // to be fair, sucha  change is probably more in the editor/backend than here when rendering;
+  // to be fair, such a change is probably more in the editor/backend than here when rendering;
   // the behaviour in ensureParamTypes is probably correct
+
+  // Apply defaults for usnet params, and coerce types and validate any set params
   const paramValues = ensureParamTypes(component.params, params);
 
   // TODO: manage passing results here too, when the platform does that again

--- a/app/client-app/src/components/shared/PageItemRender.js
+++ b/app/client-app/src/components/shared/PageItemRender.js
@@ -1,28 +1,42 @@
 import { createElement } from "react";
+import { ensureParamTypes } from "@decsys/param-types";
+import { ErrorBoundary } from "components/ErrorBoundary";
+import { Alert, AlertIcon } from "@chakra-ui/react";
 
-const PageItemRender = ({ _context, component, params }) => {
+const PageItemRenderError = ({ __BoundaryError }) => (
+  <Alert status="error">
+    <AlertIcon />
+    {__BoundaryError.message}
+  </Alert>
+);
+
+const PageItemRenderer = ({ _context, component, params }) => {
   if (!component) return null;
 
   // TODO: document the props signature change here.
   // Components now receive ({_context, ...params, ...results}) props
   // _context is prepared in the call site; this allows Previews to behave differently to Surveys
 
-  // merge default Params and set ones
   // TODO: change defaults behaviour.
   // Empty params reverting to defaults is annoying UX and sometimes prevents intentionally empty params
-  const paramDefaults = Object.keys(component.params).reduce((agg, x) => {
-    agg[x] = component.params[x].defaultValue;
-    return agg;
-  }, {});
+  // to be fair, sucha  change is probably more in the editor/backend than here when rendering;
+  // the behaviour in ensureParamTypes is probably correct
+  const paramValues = ensureParamTypes(component.params, params);
 
   // TODO: manage passing results here too, when the platform does that again
   const results = {};
 
   return createElement(component, {
-    ...{ ...paramDefaults, ...params },
+    ...{ ...params, ...paramValues }, // we also need to keep any custom editor param values (not specified in paramTypes)
     ...results,
     _context,
   });
 };
+
+const PageItemRender = (p) => (
+  <ErrorBoundary resetOnPropChanges fallback={<PageItemRenderError />}>
+    <PageItemRenderer {...p} />
+  </ErrorBoundary>
+);
 
 export default PageItemRender;

--- a/packages/param-types/.gitignore
+++ b/packages/param-types/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-*.tgz

--- a/packages/param-types/ensureParamTypes.js
+++ b/packages/param-types/ensureParamTypes.js
@@ -33,11 +33,9 @@ const validators = {
  */
 export const ensureParamTypes = (paramTypes, paramValues) => {
   // TODO: in future we can use this to check isRequired?
-  // or modify default handling for a better experience?
+  // or possibly modify default handling for a better experience?
 
   const paramKeys = Object.keys(paramTypes);
-
-  // First coerce passed values, use defaults where nothing provided
   return paramKeys.reduce((values, key) => {
     const paramType = paramTypes[key];
 

--- a/packages/param-types/ensureParamTypes.js
+++ b/packages/param-types/ensureParamTypes.js
@@ -1,0 +1,65 @@
+import * as types from "./types";
+
+const converters = {
+  [types.string]: (value) => (value != null ? value.toString() : undefined),
+  [types.oneOf]: (value) => value,
+  [types.number]: (value) => parseFloat(value),
+  [types.bool]: (value) => !!value,
+};
+
+const validators = {
+  [types.number]: {
+    isValid: (value) => !isNaN(value),
+    error: () =>
+      `The value provided is not a number, or could not be converted to one`,
+  },
+  [types.oneOf]: {
+    isValid: (value, paramType) => paramType.oneOf.includes(value),
+    error: (paramType) =>
+      `The value provided is not a valid value: ${paramType.oneOf}`,
+  },
+};
+
+/**
+ * Ensures param values adhere to a ParamTypes spec (by coercing types if necessary)
+ * and, if all values are valid, returns a new param values dictionary with the correct types.
+ *
+ * If any value cannot be coerced to a valid value (in both type and content, where appropriate)
+ * an error is thrown.
+ *
+ * @param {object} paramTypes
+ * @param {object} paramValues
+ * @returns {object} a new param values dictionary with types fixed
+ */
+export const ensureParamTypes = (paramTypes, paramValues) => {
+  // TODO: in future we can use this to check isRequired?
+  // or modify default handling for a better experience?
+
+  const paramKeys = Object.keys(paramTypes);
+
+  // First coerce passed values, use defaults where nothing provided
+  return paramKeys.reduce((values, key) => {
+    const paramType = paramTypes[key];
+
+    // First see if a value has been provided;
+    // else use default (but continue to check it to catch paramTypes errors)
+    let value = paramValues.hasOwnProperty(key)
+      ? paramValues[key]
+      : paramType.defaultValue;
+
+    // Now coerce the value to the expected type
+    value = converters[paramType.type](value);
+
+    // Now validate the coerced value
+    const validator = validators[paramType.type];
+    if (!(validator?.isValid(value, paramType) ?? true)) {
+      throw new Error(
+        `ParamType validation failed for: [${key}]: ${
+          paramValues[key]
+        }.\n${validator.error(paramType)}`
+      );
+    }
+
+    return { ...values, [key]: value };
+  }, {});
+};

--- a/packages/param-types/index.js
+++ b/packages/param-types/index.js
@@ -11,12 +11,14 @@ import {
   paramsEditorContextPropTypes,
 } from "./ResponseItemContexts";
 import buildPropTypes from "./buildPropTypes";
+import { ensureParamTypes } from "./ensureParamTypes";
 
 // named * exports
 export * from "./builders";
 
 // other named exports
 export {
+  ensureParamTypes,
   buildPropTypes,
   types,
   renderContextPropTypes,
@@ -26,6 +28,7 @@ export {
 
 // default export
 export default {
+  ensureParamTypes,
   buildPropTypes,
   ...builders,
   types,


### PR DESCRIPTION
This was causing knock on effects if Page Items didn't verify or coerce their props e.g. when doing math on what was expected to be a number but ended up being a string because of the ParamsEditor, resulting in the classic javascript issue `1 + "1" = "11"`.

Fixes:
- ParamsEditor now parses Number Input results to a float before submitting to the backend
- Page Item rendering now uses the detailed paramTypes information at its disposal to both coerce and then validate props for params.
  - This means historical data only incorrect due to the above editor bug will be interpreted correctly anyway going forward (`"0"` will cast to `0` at the point of rendering the Page Item, and intended math logic will be preserved)
  - It also means we can catch other unforeseen issues quicker; just generally makes using custom items inside the platform more robust.
  - This validation is in the ParamTypes package, so can be used by items and their stories, not just the platform
    - (built in items and their stories do not yet use it, but should in future)
- Added an `ErrorBoundary` at the point of Page Item rendering to be clear about the failure and its cause if paramType validation fails.
  - This will be useful during future development, especially of new custom items
  - It also allows for catching unforeseen platform issues more safely (before we end up with odd results data)
  - It will also help highlight discrepancies between paramTypes as written and props as used in page items.