### PR TITLE
✨Backend support for storing and setting a Question item

### DIFF
--- a/app/Decsys/Controllers/ComponentsController.cs
+++ b/app/Decsys/Controllers/ComponentsController.cs
@@ -82,6 +82,28 @@ namespace Decsys.Controllers
             return File(Encoding.UTF8.GetBytes(output.ToString()), "application/javascript");
         }
 
+        [HttpPut("{componentId}/isQuestionItem")]
+        [SwaggerOperation("Set a Component as the Question Item for a Survey Page.")]
+        [SwaggerResponse(204, "The Question Item was set successfully.")]
+        [SwaggerResponse(404, "No Page, Survey, or Component, was found with the provided ID.")]
+        public IActionResult SetQuestionItem(
+            [SwaggerParameter("ID of the Survey the Page belongs to.")]
+            int id,
+            [SwaggerParameter("ID of the Page to set the Question Item for.")]
+            Guid pageId,
+            [SwaggerParameter("ID of the Component to set as the Question Item.")]
+            Guid componentId)
+        {
+            try
+            {
+                _components.SetQuestionItem(id, pageId, componentId);
+                return NoContent();
+            } catch (KeyNotFoundException)
+            {
+                return NotFound();
+            }
+        }
+
         [HttpPost]
         [SwaggerOperation("Add a new Component to a Survey Page.")]
         [SwaggerResponse(200, "The Component was added successfully.", typeof(Component))]

--- a/app/Decsys/Controllers/ComponentsController.cs
+++ b/app/Decsys/Controllers/ComponentsController.cs
@@ -1,19 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
+
 using Decsys.Auth;
 using Decsys.Models;
 using Decsys.Services;
 using Decsys.Services.Contracts;
+
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
+
 using Newtonsoft.Json.Linq;
+
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace Decsys.Controllers
@@ -24,6 +21,7 @@ namespace Decsys.Controllers
     public class ComponentsController : ControllerBase
     {
         private readonly ComponentService _components;
+        private readonly ComponentFileService _componentFiles;
         private readonly IImageService _images;
         private readonly IConfiguration _config;
         private readonly IFileProvider _fileProvider;
@@ -32,9 +30,11 @@ namespace Decsys.Controllers
             IWebHostEnvironment env,
             IConfiguration config,
             ComponentService components,
+            ComponentFileService componentFiles,
             IImageService images)
         {
             _components = components;
+            _componentFiles = componentFiles;
             _images = images;
             _config = config;
             _fileProvider = env.ContentRootFileProvider;
@@ -61,7 +61,7 @@ namespace Decsys.Controllers
 
             var counter = 0;
 
-            foreach (var (_, file) in _components.ListFiles())
+            foreach (var (_, file) in _componentFiles.ListFiles())
             {
                 // Import the component module, and some metadata
                 output.Append(

--- a/app/Decsys/Controllers/ComponentsController.cs
+++ b/app/Decsys/Controllers/ComponentsController.cs
@@ -49,8 +49,6 @@ namespace Decsys.Controllers
         [AllowAnonymous]
         public FileResult GetComponentModules()
         {
-            // TODO: Move the hard work to a service?
-
             var output = new StringBuilder();
             const string global = "window.__DECSYS__";
             const string components = ".Components";
@@ -63,17 +61,8 @@ namespace Decsys.Controllers
 
             var counter = 0;
 
-            foreach (var file in componentFiles)
+            foreach (var (_, file) in _components.ListFiles())
             {
-                // for now we only want root .js files
-                if (file.IsDirectory || Path.GetExtension(file.PhysicalPath) != ".js") continue;
-
-                // TODO: maybe check some of the code? hmm... would need a js linter/parser/something for that
-                // maybe we can run some js unit tests for this?
-                // might be able to use node tools for this, but we'll need node on the server
-                // which is a bit rubbish for running outside docker...
-                // particularly in a "local" install
-
                 // Import the component module, and some metadata
                 output.Append(
                     "import Decsys").Append(++counter)

--- a/app/Decsys/Data/Entities/BaseComponent.cs
+++ b/app/Decsys/Data/Entities/BaseComponent.cs
@@ -24,5 +24,11 @@ namespace Decsys.Data.Entities
         public int Order { get; set; }
 
         public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether this item is used to provide meaningful "Question"
+        /// content in aggregated results
+        /// </summary>
+        public bool IsQuestionItem { get; set; }
     }
 }

--- a/app/Decsys/Models/Component.cs
+++ b/app/Decsys/Models/Component.cs
@@ -17,5 +17,11 @@ namespace Decsys.Models
         public Guid Id { get; set; } = Guid.NewGuid();
 
         public JObject Params { get; set; } = new JObject();
+
+        /// <summary>
+        /// Whether this item is used to provide meaningful "Question"
+        /// content in aggregated results
+        /// </summary>
+        public bool IsQuestionItem { get; set; }
     }
 }

--- a/app/Decsys/ServiceCollectionExtensions.cs
+++ b/app/Decsys/ServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ namespace Decsys
             => s.AddTransient<SurveyService>()
                 .AddTransient<PageService>()
                 .AddTransient<ComponentService>()
+                .AddTransient<ComponentFileService>()
                 .AddTransient<SurveyInstanceService>()
                 .AddTransient<ExportService>()
                 .AddTransient<ParticipantEventService>()

--- a/app/Decsys/Services/ComponentFileService.cs
+++ b/app/Decsys/Services/ComponentFileService.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Decsys.Services
+{
+    /// <summary>
+    /// Survey Page functionality
+    /// </summary>
+    public class ComponentFileService
+    {
+        private readonly IConfiguration _config;
+        private readonly IFileProvider _fileProvider;
+
+
+        public ComponentFileService(IConfiguration config, IWebHostEnvironment env)
+        {
+            _config = config;
+            _fileProvider = env.ContentRootFileProvider;
+        }
+
+        /// <summary>
+        /// List Component Files from disk, with their names
+        /// </summary>
+        /// <returns></returns>
+        public List<(string name, IFileInfo file)> ListFiles()
+        => _fileProvider.GetDirectoryContents(
+                _config["Paths:Components:Root"]).Aggregate(new List<(string, IFileInfo)>(), (result, file) =>
+                {
+                    // for now we only want root .js files
+                    if (file.IsDirectory || Path.GetExtension(file.PhysicalPath) != ".js")
+                        return result;
+
+                    // TODO: maybe check some of the code? hmm... would need a js linter/parser/something for that
+                    // maybe we can run some js unit tests for this?
+                    // might be able to use node tools for this, but we'll need node on the server
+                    // which is a bit rubbish for running outside docker...
+                    // particularly in a "local" install
+
+                    result.Add((Path.GetFileNameWithoutExtension(file.PhysicalPath), file));
+                    return result;
+                });
+
+        /// <summary>
+        /// Check if a given component type matches one of the loaded responses
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public bool IsResponseItem(string type) => ListFiles().Any(x => x.name == type);
+    }
+}

--- a/app/Decsys/Services/ComponentService.cs
+++ b/app/Decsys/Services/ComponentService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using Decsys.Repositories.Contracts;
 using Decsys.Models;
@@ -8,8 +5,8 @@ using Decsys.Models;
 using LiteDB;
 
 using Newtonsoft.Json.Linq;
-using System.Threading.Tasks;
 using Decsys.Services.Contracts;
+using Microsoft.Extensions.FileProviders;
 
 namespace Decsys.Services
 {
@@ -21,13 +18,47 @@ namespace Decsys.Services
         private readonly IComponentRepository _components;
         private readonly ISurveyRepository _surveys;
         private readonly IImageService _images;
+        private readonly IConfiguration _config;
+        private readonly IFileProvider _fileProvider;
 
-        public ComponentService(IComponentRepository components, ISurveyRepository surveys, IImageService images)
+
+        public ComponentService(IComponentRepository components, ISurveyRepository surveys, IImageService images, IConfiguration config, IWebHostEnvironment env)
         {
             _components = components;
             _surveys = surveys;
             _images = images;
+            _config = config;
+            _fileProvider = env.ContentRootFileProvider;
         }
+
+        /// <summary>
+        /// List Component Files from disk, with their names
+        /// </summary>
+        /// <returns></returns>
+        public List<(string name, IFileInfo file)> ListFiles()
+        => _fileProvider.GetDirectoryContents(
+                _config["Paths:Components:Root"]).Aggregate(new List<(string, IFileInfo)>(), (result, file) =>
+                {
+                    // for now we only want root .js files
+                    if (file.IsDirectory || Path.GetExtension(file.PhysicalPath) != ".js")
+                        return result;
+
+                    // TODO: maybe check some of the code? hmm... would need a js linter/parser/something for that
+                    // maybe we can run some js unit tests for this?
+                    // might be able to use node tools for this, but we'll need node on the server
+                    // which is a bit rubbish for running outside docker...
+                    // particularly in a "local" install
+
+                    result.Add((Path.GetFileNameWithoutExtension(file.PhysicalPath), file));
+                    return result;
+                });
+
+        /// <summary>
+        /// Check if a given component type matches one of the loaded responses
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public bool IsResponseItem(string type) => ListFiles().Any(x => x.name == type);
 
         /// <summary>
         /// Create a new Component in a given Survey Page.

--- a/app/Decsys/Services/ComponentService.cs
+++ b/app/Decsys/Services/ComponentService.cs
@@ -147,6 +147,32 @@ namespace Decsys.Services
             _components.Update(surveyId, pageId, component);
         }
 
+        /// <summary>
+        /// Set the specified component as the Page's `QuestionItem`.
+        ///
+        /// Also removes the `QuestionItem` status from any component
+        /// on the page that currently has it.
+        /// </summary>
+        /// <param name="surveyId"></param>
+        /// <param name="pageId"></param>
+        /// <param name="componentId"></param>
+        /// <exception cref="KeyNotFoundException"></exception>
+        public void SetQuestionItem(int surveyId, Guid pageId, Guid componentId)
+        {
+            var components = _components.List(surveyId, pageId);
+            var newQ = components.SingleOrDefault(x => x.Id == componentId)
+                ?? throw new KeyNotFoundException("Component could not be found.");
+
+            var oldQ = components.SingleOrDefault(x => x.IsQuestionItem);
+            if (oldQ is not null)
+            {
+                oldQ.IsQuestionItem = false;
+                _components.Update(surveyId, pageId, oldQ);
+            }
+
+            newQ.IsQuestionItem = true;
+            _components.Update(surveyId, pageId, newQ);
+        }
 
         /// <summary>
         /// Duplicate a component in a Page

--- a/app/Decsys/Services/ComponentService.cs
+++ b/app/Decsys/Services/ComponentService.cs
@@ -32,35 +32,6 @@ namespace Decsys.Services
         }
 
         /// <summary>
-        /// List Component Files from disk, with their names
-        /// </summary>
-        /// <returns></returns>
-        public List<(string name, IFileInfo file)> ListFiles()
-        => _fileProvider.GetDirectoryContents(
-                _config["Paths:Components:Root"]).Aggregate(new List<(string, IFileInfo)>(), (result, file) =>
-                {
-                    // for now we only want root .js files
-                    if (file.IsDirectory || Path.GetExtension(file.PhysicalPath) != ".js")
-                        return result;
-
-                    // TODO: maybe check some of the code? hmm... would need a js linter/parser/something for that
-                    // maybe we can run some js unit tests for this?
-                    // might be able to use node tools for this, but we'll need node on the server
-                    // which is a bit rubbish for running outside docker...
-                    // particularly in a "local" install
-
-                    result.Add((Path.GetFileNameWithoutExtension(file.PhysicalPath), file));
-                    return result;
-                });
-
-        /// <summary>
-        /// Check if a given component type matches one of the loaded responses
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        public bool IsResponseItem(string type) => ListFiles().Any(x => x.name == type);
-
-        /// <summary>
         /// Create a new Component in a given Survey Page.
         /// </summary>
         /// <param name="surveyId">The ID of the Survey the Page belongs to.</param>


### PR DESCRIPTION
The backend stores a flag `isQuestionItem` on Page Items.

This property is returned on Page Items from the API, and a new endpoint has been added to allow setting a single Page Item as the current "Question Item".