### PR TITLE
✨ Backend Question Content properties + Question in JSON Summary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
     "**/.pnp.*": true
   },
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "FSharp.suggestGitignore": false
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "**/.pnp.*": true
   },
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "FSharp.suggestGitignore": false
 }

--- a/app/Decsys/Constants/BuiltInPageItems.cs
+++ b/app/Decsys/Constants/BuiltInPageItems.cs
@@ -1,6 +1,6 @@
 ﻿namespace Decsys.Constants;
 
-public readonly record struct PageItemMetadata(string Type, string questionContent);
+public record PageItemMetadata(string Type, string QuestionContent);
 
 public static class BuiltInPageItems
 {
@@ -18,5 +18,12 @@ public static class BuiltInPageItems
     /// <param name="type"></param>
     /// <returns></returns>
     public static bool IsBuiltIn(string type) => pageItems.ContainsKey(type);
+
+    /// <summary>
+    /// Get the metadata for a built in type, or null
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static PageItemMetadata? Metadata(string type) => pageItems[type];
 }
 

--- a/app/Decsys/Constants/BuiltInPageItems.cs
+++ b/app/Decsys/Constants/BuiltInPageItems.cs
@@ -1,0 +1,22 @@
+﻿namespace Decsys.Constants;
+
+public readonly record struct PageItemMetadata(string Type, string questionContent);
+
+public static class BuiltInPageItems
+{
+    private static readonly Dictionary<string, PageItemMetadata> pageItems = new()
+    {
+        ["heading"] = new("heading", "text"),
+        ["paragraph"] = new("paragraph", "text"),
+        ["image"] = new("image", "questionContent"),
+        ["spacer"] = new("spacer", "questionContent"),
+    };
+
+    /// <summary>
+    /// Determine if the specified Page Item type is a built-in type the backend is aware of
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static bool IsBuiltIn(string type) => pageItems.ContainsKey(type);
+}
+

--- a/app/Decsys/Data/Entities/BaseParticipantEvent.cs
+++ b/app/Decsys/Data/Entities/BaseParticipantEvent.cs
@@ -4,13 +4,10 @@ namespace Decsys.Data.Entities
 {
     public abstract class BaseParticipantEvent
     {
-        public int Id { get; set; }
-
         public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
 
         public string Source { get; set; } = string.Empty;
 
         public string Type { get; set; } = string.Empty;
-
     }
 }

--- a/app/Decsys/Data/Entities/LiteDb/ParticipantEvent.cs
+++ b/app/Decsys/Data/Entities/LiteDb/ParticipantEvent.cs
@@ -4,6 +4,11 @@ namespace Decsys.Data.Entities.LiteDb
 {
     public class ParticipantEvent : BaseParticipantEvent
     {
+        /// <summary>
+        /// PK
+        /// </summary>
+        public int Id { get; set; }
+
         public BsonDocument Payload { get; set; } = new BsonDocument();
     }
 }

--- a/app/Decsys/Data/Entities/Mongo/ParticipantEvent.cs
+++ b/app/Decsys/Data/Entities/Mongo/ParticipantEvent.cs
@@ -1,9 +1,11 @@
 
 
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace Decsys.Data.Entities.Mongo
 {
+    [BsonIgnoreExtraElements]
     public class ParticipantEvent : BaseParticipantEvent
     {
         public BsonDocument Payload { get; set; } = new BsonDocument();

--- a/app/Decsys/Models/Component.cs
+++ b/app/Decsys/Models/Component.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json.Linq;
-using System;
 
 namespace Decsys.Models
 {

--- a/app/Decsys/Models/PageResponseSummary.cs
+++ b/app/Decsys/Models/PageResponseSummary.cs
@@ -15,7 +15,16 @@ namespace Decsys.Models
         /// </summary>
         public int Page { get; set; }
 
+        /// <summary>
+        /// The user specified name for the Page
+        /// </summary>
         public string PageName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The content used as the "Question Content"
+        /// from the Page Item designated as the "Question Item"
+        /// </summary>
+        public string? Question { get; set; } = null;
 
         /// <summary>
         /// The question component type

--- a/app/Decsys/Program.cs
+++ b/app/Decsys/Program.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.OpenApi.Models;
 
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 #region Host Creation

--- a/app/Decsys/Repositories/Mongo/ParticipantEventRepository.cs
+++ b/app/Decsys/Repositories/Mongo/ParticipantEventRepository.cs
@@ -51,25 +51,11 @@ namespace Decsys.Repositories.Mongo
         private string GetParticipantId(string collectionName)
             => collectionName.Substring($"{Collections.EventLog}_".Length);
 
-        private int GetNextEventId(IMongoCollection<ParticipantEvent> log)
-        {
-            // mongo has no integer id generator
-            // so we set integer id's at insert
-            var lastId = log.Find(new BsonDocument())
-                .SortByDescending(x => x.Id)
-                .FirstOrDefault()?
-                .Id ?? 0;
-
-            return ++lastId;
-
-        }
-
         public void Create(int instanceId, string participantId, Models.ParticipantEvent e)
         {
             var log = FindLog(instanceId, participantId);
 
             var entity = _mapper.Map<ParticipantEvent>(e);
-            entity.Id = GetNextEventId(log);
 
             log.InsertOne(entity);
         }


### PR DESCRIPTION
Provides lookups in the backend for question content property on built-in (content) page items.

Uses the designated property on "Question Item"s to put a "question" property in JSON summary exports.