### PR TITLE
🐛 fixed duplicating page items

### DIFF
--- a/app/Decsys/Constants/BuiltInPageItems.cs
+++ b/app/Decsys/Constants/BuiltInPageItems.cs
@@ -4,12 +4,17 @@ public record PageItemMetadata(string Type, string QuestionContent);
 
 public static class BuiltInPageItems
 {
+    public const string Heading = "heading";
+    public const string Paragraph = "paragraph";
+    public const string Image = "image";
+    public const string Spacer = "spacer";
+
     private static readonly Dictionary<string, PageItemMetadata> pageItems = new()
     {
-        ["heading"] = new("heading", "text"),
-        ["paragraph"] = new("paragraph", "text"),
-        ["image"] = new("image", "questionContent"),
-        ["spacer"] = new("spacer", "questionContent"),
+        [Heading] = new(Heading, "text"),
+        [Paragraph] = new(Paragraph, "text"),
+        [Image] = new(Image, "questionContent"),
+        [Spacer] = new(Spacer, "questionContent"),
     };
 
     /// <summary>

--- a/app/Decsys/Services/ComponentService.cs
+++ b/app/Decsys/Services/ComponentService.cs
@@ -197,7 +197,8 @@ namespace Decsys.Services
             };
             components.Insert(i + 1, dupe);
 
-            await _images.CopyImage(surveyId, pageId, componentId, dupe.Id);
+            if(dupe.Type == Constants.BuiltInPageItems.Image)
+                await _images.CopyImage(surveyId, pageId, componentId, dupe.Id);
 
             _components.Replace(surveyId, pageId, components.Select((x, i) => { x.Order = i + 1; return x; }));
 

--- a/app/Decsys/Services/ImageService/LocalFileImageService.cs
+++ b/app/Decsys/Services/ImageService/LocalFileImageService.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 using Decsys.Repositories.Contracts;
 using Decsys.Services.Contracts;
@@ -114,10 +109,9 @@ namespace Decsys.Services
         public async Task<bool> HasImages(int surveyId)
             => (await Enumerate(surveyId)).Any();
 
-        private string GetStoredFileExtension(int surveyId, Guid pageId, Guid componentId) =>
+        private string? GetStoredFileExtension(int surveyId, Guid pageId, Guid componentId) =>
             _components.Find(surveyId, pageId, componentId)
-                .Params.Value<string>("extension")
-            ?? throw new InvalidOperationException("Couldn't find a valid string param for `extension`.");
+                .Params.Value<string>("extension");
 
         public async Task<byte[]> GetImage(int surveyId, string filename)
         => await File.ReadAllBytesAsync(

--- a/app/Decsys/Services/ImageService/MongoImageService.cs
+++ b/app/Decsys/Services/ImageService/MongoImageService.cs
@@ -1,14 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Decsys.Config;
 using Decsys.Constants;
 using Decsys.Repositories.Contracts;
 using Decsys.Services.Contracts;
-using Microsoft.AspNetCore.Routing.Constraints;
+
 using Microsoft.Extensions.Options;
+
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 
@@ -128,9 +124,8 @@ namespace Decsys.Services
                     .FindAsync(Builders<GridFSFileInfo>.Filter.Empty))
                 .AnyAsync();
 
-        private string GetStoredFileExtension(int surveyId, Guid pageId, Guid componentId) =>
+        private string? GetStoredFileExtension(int surveyId, Guid pageId, Guid componentId) =>
             _components.Find(surveyId, pageId, componentId)
-                .Params.Value<string>("extension")
-            ?? throw new InvalidOperationException("Couldn't find a valid string param for `extension`.");
+                .Params.Value<string>("extension");
     }
 }


### PR DESCRIPTION
due to nullable changes in .net 6, some nullables were made non-nullable and throwing exceptions. This makes them nullable as expected again, and also only runs the pertinent code when applicable.