### PR TITLE
AB#85979: Participant counts fix

### DIFF
--- a/app/Decsys/Decsys.csproj
+++ b/app/Decsys/Decsys.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/app/Decsys/Models/SurveySummary.cs
+++ b/app/Decsys/Models/SurveySummary.cs
@@ -28,6 +28,8 @@ namespace Decsys.Models
         public int? ActiveInstanceId { get; set; }
 
         public int? ParentSurveyId { get; set; }
+        
+        public int ActiveInstanceParticipantCount { get; set; }
 
         public List<SurveySummary>? Children { get; set; }
     }

--- a/app/Decsys/Repositories/Contracts/IParticipantEventRepository.cs
+++ b/app/Decsys/Repositories/Contracts/IParticipantEventRepository.cs
@@ -7,6 +7,13 @@ namespace Decsys.Repositories.Contracts
     public interface IParticipantEventRepository
     {
         /// <summary>
+        /// Get the current count of Participants for a given Survey Instance
+        /// </summary>
+        /// <param name="instanceId">ID of the Instance</param>
+        /// <returns></returns>
+        int GetParticipantCount(int instanceId);
+        
+        /// <summary>
         /// List all Events for a Participant, ordered by Timestamp
         /// </summary>
         /// <param name="instanceId">ID of the Instance the Participant belongs to</param>

--- a/app/Decsys/Repositories/LiteDb/LiteDbParticipantEventRepository.cs
+++ b/app/Decsys/Repositories/LiteDb/LiteDbParticipantEventRepository.cs
@@ -83,6 +83,9 @@ namespace Decsys.Repositories.LiteDb
 
         #endregion
 
+        public int GetParticipantCount(int instanceId)
+            => ListLogs(instanceId).Count;
+        
         public void Delete(int instanceId)
             => _db.DropInstanceEventLog(instanceId);
 

--- a/app/Decsys/Repositories/LiteDb/LiteDbSurveyRepository.cs
+++ b/app/Decsys/Repositories/LiteDb/LiteDbSurveyRepository.cs
@@ -80,6 +80,10 @@ namespace Decsys.Repositories.LiteDb
                             x.InstanceId == latestInstanceId)
                         .SingleOrDefault() is null;
 
+                if (latestInstanceId.HasValue)
+                    survey.ActiveInstanceParticipantCount =
+                        _events.GetParticipantCount(latestInstanceId.Value);
+                
                 return summary;
             }
 

--- a/app/Decsys/Repositories/Mongo/ParticipantEventRepository.cs
+++ b/app/Decsys/Repositories/Mongo/ParticipantEventRepository.cs
@@ -31,6 +31,9 @@ namespace Decsys.Repositories.Mongo
             _mapper = mapper;
         }
 
+        public int GetParticipantCount(int instanceId)
+            => ListLogs(instanceId).Count;
+
         private IMongoDatabase EventLogDb(int instanceId)
             => _mongo.GetDatabase(
                 $"{_config.DatabaseName}_{Collections.InstanceDb}{instanceId}");

--- a/app/Decsys/Repositories/Mongo/SurveyRepository.cs
+++ b/app/Decsys/Repositories/Mongo/SurveyRepository.cs
@@ -287,6 +287,10 @@ namespace Decsys.Repositories.Mongo
                             x.InstanceId == latestInstanceId)
                         .SingleOrDefault() is null;
 
+                if (latestInstanceId.HasValue)
+                    survey.ActiveInstanceParticipantCount =
+                        _events.GetParticipantCount(latestInstanceId.Value);
+                
                 return summary;
             }
 

--- a/app/client-app/src/app/pages/Surveys/components/SurveyCard/ActiveInstanceLine.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyCard/ActiveInstanceLine.jsx
@@ -65,22 +65,13 @@ const InternalTypeInfo = ({ friendlyId }) => (
   </>
 );
 
-export const RespondentCountBadge = ({ friendlyId, isStudy }) => {
-  const [results, setResults] = useState({});
-  useEffect(() => {
-    (async () => {
-      const [surveyId, instanceId] = decode(friendlyId);
-      const { data } = await getInstanceResultsSummary(surveyId, instanceId);
-      setResults(data);
-    })();
-  }, [friendlyId]);
-
+export const RespondentCountBadge = ({ count, isStudy }) => {
   // TODO: fix for studies
   if (isStudy) return null;
 
   return (
     <Badge textAlign="center" colorScheme="cyan" variant="outline" p={1}>
-      {results?.participants?.length ?? 0} respondents
+      {count ?? 0} respondents
     </Badge>
   );
 };
@@ -93,6 +84,7 @@ const ActiveInstanceLine = ({
   settings,
   hasInvalidExternalLink,
   runCount,
+  activeInstanceParticipantCount,
   isStudy,
 }) => {
   const instanceValidIdModal = useDisclosure();
@@ -102,7 +94,10 @@ const ActiveInstanceLine = ({
     <>
       <Flex align="center" px={2} py={1}>
         <Stack direction="row" alignItems="center">
-          <RespondentCountBadge friendlyId={friendlyId} isStudy={isStudy} />
+          <RespondentCountBadge
+            count={activeInstanceParticipantCount}
+            isStudy={isStudy}
+          />
           {type ? (
             <ExternalTypeInfo
               friendlyId={friendlyId}

--- a/app/client-app/src/app/pages/Surveys/components/SurveyCard/SurveyInfoLine.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyCard/SurveyInfoLine.jsx
@@ -62,6 +62,7 @@ const SurveyInfoLine = ({
   runCount,
   type,
   parentSurveyId,
+  activeInstanceParticipantCount,
   hasInvalidExternalLink,
   isStudy,
   friendlyId,
@@ -99,7 +100,7 @@ const SurveyInfoLine = ({
       </Flex>
       {parentSurveyId && friendlyId && (
         <Stack direction="row" alignItems="center">
-          <RespondentCountBadge friendlyId={friendlyId} />
+          <RespondentCountBadge count={activeInstanceParticipantCount} />
         </Stack>
       )}
     </>

--- a/app/client-app/src/app/pages/Surveys/components/SurveyCard/index.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyCard/index.jsx
@@ -31,6 +31,7 @@ const SurveyCard = () => {
   const { colorMode } = useColorMode();
   const style = themes.sharedStyles.card;
   const survey = useSurvey();
+  console.log(survey);
   const {
     id,
     activeInstanceId,

--- a/app/client-app/src/app/pages/Surveys/components/SurveyCard/index.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyCard/index.jsx
@@ -31,7 +31,6 @@ const SurveyCard = () => {
   const { colorMode } = useColorMode();
   const style = themes.sharedStyles.card;
   const survey = useSurvey();
-  console.log(survey);
   const {
     id,
     activeInstanceId,


### PR DESCRIPTION
## Overview

This PR changes Participant (Respondent) counts in the Admin Surveys List to be returned with the Survey summary, instead of being calculated independently for each card by pulling the entire results set of the current active instance.