### PR TITLE
Fixing docs deployment

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,8 @@
   - app/client-app/**/*
 "Area: Backend API":
   - app/Decsys/**/*
+"Area: Docs":
+  - docs/**/*
 
 # label types of changes contained in a PR
 "Contains: Migrations":

--- a/.github/workflows/build.docs.yml
+++ b/.github/workflows/build.docs.yml
@@ -6,10 +6,10 @@ on:
     branches: [main]
     paths:
       - docs/**
-      - .github/workflows/deploy.docs.yml
+      - .github/workflows/build.docs.yml
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -2,7 +2,7 @@ name: GitHub Pages Docs
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches: [main]
     paths:
       - docs/**

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -2,7 +2,7 @@ name: GitHub Pages Docs
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches: [main]
     paths:
       - docs/**

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -33,3 +33,5 @@ jobs:
           publish_dir: ./docs/build
           publish_branch: main
           force_orphan: true
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -28,13 +28,8 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
+          deploy_key: ${{ secrets.GH_PAGES_DEPLOY }}
+          external_repository: decsys/decsys.github.io
           publish_dir: ./docs/build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          publish_branch: main
+          force_orphan: true


### PR DESCRIPTION
<!--
⚠ Ensure the PR title starts with a reference to the primary work item it completes, in the form `AB#<id>: My PR Title`.
-->

## Overview

This PR fixes docs deployment so we deploy to https://decsys.github.io instead of this repo's Github Pages

<!--
ℹ If there are multiple relevant Azure Boards work items, please reference them in a list below, in the form `AB#<id>`.

Otherwise delete the section.
-->