### PR TITLE
AB#101210: Heading and empty response next button fix

### DIFF
--- a/app/client-app/src/app/pages/Editor/components/PageList/DraggablePageItem.jsx
+++ b/app/client-app/src/app/pages/Editor/components/PageList/DraggablePageItem.jsx
@@ -95,9 +95,12 @@ const QuestionButton = ({ isQuestionItem, id, setQuestionItem, type }) => {
   );
 };
 
-const OptionalButton = ({ isOptional, id, setIsOptional }) => {
+const OptionalButton = ({ isOptional, id, setIsOptional, type }) => {
   const handleOptionalClick = () => setIsOptional(id, !isOptional);
   const { busy } = usePageListContext();
+  if (isBuiltIn(type)) {
+    return <Flex pl={8} align="center"></Flex>;
+  }
 
   if (some(busy)) {
     const p = { p: "9px", dotSize: "14px" };
@@ -149,6 +152,7 @@ export const ItemInfo = ({
         isOptional={isOptional}
         setIsOptional={setIsOptional}
         id={id}
+        type={type}
       />
     )}
     <Icon as={!type || isBusy ? BsDot : FaGripVertical} color="gray.500" />

--- a/app/client-app/src/components/shared/SurveyPage.jsx
+++ b/app/client-app/src/components/shared/SurveyPage.jsx
@@ -57,12 +57,12 @@ const SurveyPage = ({
       setResultLogged(false);
       if (
         getPageResponseItem(page.components) &&
-        page.components[0].isOptional === true
+        page.components?.some((component) => component.isOptional) === true
       )
         setNextEnabled(true);
       else if (
         getPageResponseItem(page.components) &&
-        page.components[0].isOptional === false
+        page.components?.some((component) => component.isOptional) === false
       )
         setNextEnabled(false);
       else setNextEnabled(true);
@@ -70,12 +70,16 @@ const SurveyPage = ({
   }, [previousPageId, page, logEvent]);
 
   useEffect(() => {
-    const optionalComponent = page.components[0]?.isOptional;
+    const hasOptionalComponent = page.components?.some(
+      (component) => component.isOptional
+    );
     const shouldEnableNext =
-      optionalComponent || (isValidResponse && resultLogged);
+      hasOptionalComponent ||
+      (isValidResponse && resultLogged) ||
+      !getPageResponseItem(page.components);
 
     setNextEnabled(shouldEnableNext);
-  }, [isValidResponse, resultLogged]);
+  }, [isValidResponse, resultLogged, page.components?.length]);
 
   const renderContext = {
     pageId: page.id,

--- a/app/client-app/src/components/shared/SurveyPage.jsx
+++ b/app/client-app/src/components/shared/SurveyPage.jsx
@@ -57,7 +57,7 @@ const SurveyPage = ({
       setResultLogged(false);
       if (
         getPageResponseItem(page.components) &&
-        page.components?.some((component) => component.isOptional) === true
+        page.components?.some((component) => component.isOptional)
       )
         setNextEnabled(true);
       else if (

--- a/app/client-app/src/components/shared/SurveyPage.jsx
+++ b/app/client-app/src/components/shared/SurveyPage.jsx
@@ -62,7 +62,7 @@ const SurveyPage = ({
         setNextEnabled(true);
       else if (
         getPageResponseItem(page.components) &&
-        page.components?.some((component) => component.isOptional) === false
+        !page.components?.some((component) => component.isOptional)
       )
         setNextEnabled(false);
       else setNextEnabled(true);


### PR DESCRIPTION
Heading no longer display optional/manditory  FaAsterisk icon
Can click next on an Empty response page 
Instead of comparing the first index component[0].isOptional, it checks if it has any optional components