### PR TITLE
AB#102269: fixed Number Params inputs when using the steppers

### DIFF
--- a/app/client-app/src/app/pages/Editor/components/PageItemEditor/Param.jsx
+++ b/app/client-app/src/app/pages/Editor/components/PageItemEditor/Param.jsx
@@ -12,6 +12,14 @@ import {
 import { useDerivedState } from "hooks/useDerivedState";
 import useDeferredAction from "hooks/useDeferredAction";
 
+/**
+ * Try and convert a string to a number, else use a fallback value
+ */
+const convertStringToNumber = (text, fallback) => {
+  const n = parseFloat(text);
+  return isNaN(n) ? fallback : n;
+};
+
 const useDeferredChangeHandler = (paramKey, init, onChange) => {
   const [value, setValue] = useDerivedState(init);
 
@@ -29,8 +37,7 @@ const useDeferredChangeHandler = (paramKey, init, onChange) => {
       case "string":
         // make sure we convert back to a number, though!
         // else items may receive strings they weren't expecting, and do invalid math!
-        const n = parseFloat(e);
-        inputValue = isNaN(n) ? init : n;
+        inputValue = convertStringToNumber(e, init);
         break;
       case "object":
         inputValue = e.target.value;
@@ -95,8 +102,8 @@ const Param = ({ paramKey, value, type, oneOf, onChange }) => {
           >
             <NumberInputField />
             <NumberInputStepper>
-              <NumberIncrementStepper onClick={handleValueChange} />
-              <NumberDecrementStepper onClick={handleValueChange} />
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
             </NumberInputStepper>
           </NumberInput>
         );


### PR DESCRIPTION
## Overview
 
This PR fixes an issue where using the number steppers (up/down arrow buttons) on a number input for a page item param caused a UI issue.

The steppers were updating the state with an invalid value (either a string or undefined), but the input change handler then resolved it after a deferred timeout.

The steppers now don't update the value, leaving it to the input's deferred update instead.