### PR TITLE
AB#101772: Add secure webhooks

### DIFF
--- a/app/Decsys/Data/Entities/Mongo/Webhook.cs
+++ b/app/Decsys/Data/Entities/Mongo/Webhook.cs
@@ -7,7 +7,7 @@ public class Webhook
     public int Id { get; set; }
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string SecretHash { get; set; } = string.Empty;
+    public string? SecretHash { get; set; }
     public bool VerifySsl { get; set; }
 
     public List<TriggerCriteria> TriggerCriteria { get; set; } = new List<TriggerCriteria>();

--- a/app/Decsys/Data/Entities/Mongo/Webhook.cs
+++ b/app/Decsys/Data/Entities/Mongo/Webhook.cs
@@ -7,7 +7,7 @@ public class Webhook
     public int Id { get; set; }
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string Secret { get; set; } = string.Empty;
+    public string SecretHash { get; set; } = string.Empty;
     public bool VerifySsl { get; set; }
 
     public List<TriggerCriteria> TriggerCriteria { get; set; } = new List<TriggerCriteria>();

--- a/app/Decsys/Models/Webhooks/WebhookModel.cs
+++ b/app/Decsys/Models/Webhooks/WebhookModel.cs
@@ -4,7 +4,7 @@ public class WebhookModel
 {
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string Secret { get; set; } = string.Empty;
+    public string SecretHash { get; set; } = string.Empty;
     public bool VerifySsl { get; set; }
     
     /// <summary>

--- a/app/Decsys/Models/Webhooks/WebhookModel.cs
+++ b/app/Decsys/Models/Webhooks/WebhookModel.cs
@@ -4,7 +4,7 @@ public class WebhookModel
 {
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string SecretHash { get; set; } = string.Empty;
+    public string? SecretHash { get; set; }
     public bool VerifySsl { get; set; }
     
     /// <summary>

--- a/app/Decsys/Repositories/Mongo/WebhookRepository.cs
+++ b/app/Decsys/Repositories/Mongo/WebhookRepository.cs
@@ -27,7 +27,7 @@ public class WebhookRepository : IWebhookRepository
         {
             SurveyId = webhook.SurveyId,
             CallbackUrl = webhook.CallbackUrl,
-            Secret = webhook.Secret,
+            SecretHash = webhook.SecretHash,
             VerifySsl = webhook.VerifySsl,
             TriggerCriteria = webhook.TriggerCriteria
         };
@@ -44,7 +44,7 @@ public class WebhookRepository : IWebhookRepository
                 {
                     SurveyId = x.SurveyId,
                     CallbackUrl = x.CallbackUrl,
-                    Secret = x.Secret,
+                    SecretHash = x.SecretHash,
                     VerifySsl = x.VerifySsl,
                     TriggerCriteria = x.TriggerCriteria
                 })).ToList();

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -40,7 +40,7 @@ public class WebhookService
         {
             if (FilterCriteria(webhook, payload))
             {
-                await SendWebhook(payload, webhook.CallbackUrl);
+                await SendWebhook(webhook, payload);
             }
         }
     }
@@ -84,13 +84,15 @@ public class WebhookService
     /// Posts webhook data to a given URL.
     /// </summary>
     /// <param name="payload">Payload to Post</param>
-    /// <param name="callbackUrl">Callback url to post to</param>
-    private async Task SendWebhook(PayloadModel payload, string callbackUrl)
+    /// <param name="webhook">Webhook to Post to</param>
+    private async Task SendWebhook(WebhookModel webhook, PayloadModel payload)
     {
         var json = JsonConvert.SerializeObject(payload);
-        
+
         var content = new StringContent(json, Encoding.UTF8, "application/json");
-        await _client.PostAsync(callbackUrl, content);
+        if (webhook.SecretHash is not null) content.Headers.Add("X-Decsys-Signature", webhook.SecretHash);
+
+        await _client.PostAsync(webhook.CallbackUrl, content);
     }
 
 }


### PR DESCRIPTION
## Overview

Renames the secret on the Webhook to be SecretHash - as this is what we're storing.
Adds it as a custom header if it is present when the webhook is posted. 