### PR TITLE
AB#107350: Url Ids update

### DIFF
--- a/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
@@ -18,13 +18,22 @@ import {
 } from "@chakra-ui/react";
 import generateGfyCatStyleUrl from "services/gfycat-style-urls.js";
 import produce from "immer";
+import { fetchWordList } from "api/wordlist";
 
 const ParticipantIdentifiersConfig = ({ data, mutate }) => {
   const [idGenCount, setIdGenCount] = useState(10);
+  const [wordList, setWordList] = useState(null);
+
   const handleGenCountChange = ({ target: { value } }) =>
     setIdGenCount(parseInt(value));
 
-  const handleIdGenClick = () =>
+  const getWordList = async () => {
+    const data = await fetchWordList();
+    setWordList(data);
+  };
+
+  const handleIdGenClick = async () => {
+    await getWordList();
     mutate(
       produce((config) => {
         config.validIdentifiers.push(
@@ -35,6 +44,7 @@ const ParticipantIdentifiersConfig = ({ data, mutate }) => {
       }),
       false
     );
+  };
 
   return (
     <>

--- a/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FaInfoCircle, FaClipboardList } from "react-icons/fa";
 import {
   Flex,
@@ -32,19 +32,21 @@ const ParticipantIdentifiersConfig = ({ data, mutate }) => {
     setWordList(data);
   };
 
-  const handleIdGenClick = async () => {
-    await getWordList();
+  useEffect(() => {
+    getWordList(wordList);
+  }, []);
+
+  const handleIdGenClick = () =>
     mutate(
       produce((config) => {
         config.validIdentifiers.push(
           ...Array(idGenCount)
-            .fill(() => generateGfyCatStyleUrl(1, "", true))
+            .fill(() => generateGfyCatStyleUrl(wordList, 1, "", true))
             .map((x) => x())
         );
       }),
       false
     );
-  };
 
   return (
     <>

--- a/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
+++ b/app/client-app/src/app/pages/Surveys/components/SurveyConfigModal/ParticipantIdentifiersConfig.jsx
@@ -41,7 +41,9 @@ const ParticipantIdentifiersConfig = ({ data, mutate }) => {
       produce((config) => {
         config.validIdentifiers.push(
           ...Array(idGenCount)
-            .fill(() => generateGfyCatStyleUrl(wordList, 1, "", true))
+            .fill(() =>
+              generateGfyCatStyleUrl(wordList.excludedBuiltins, 1, "", true)
+            )
             .map((x) => x())
         );
       }),

--- a/app/client-app/src/services/gfycat-style-urls.js
+++ b/app/client-app/src/services/gfycat-style-urls.js
@@ -7,26 +7,40 @@
 
 import adjectives from "./adjectives";
 import animals from "./animals";
+import { toDictionary } from "./data-structures";
 
 const generateGfyCatStyleUrl = (
+  wordlist,
   numAdjectives,
   delimiter,
   capitalizeFirstLetter
 ) => {
   let combination = "";
-  const animal = animals[Math.floor(Math.random() * animals.length)];
+
+  const excludedBuitinWords = toDictionary(wordlist.excludedBuiltins, "word");
+
+  // Filter adjectives array
+  const filteredAdjectives = adjectives.filter(
+    (adjective) => !excludedBuitinWords[adjective]
+  );
+  const filteredNouns = animals.filter(
+    (adjective) => !excludedBuitinWords[adjective]
+  );
 
   for (let i = 0; i < numAdjectives; i++) {
-    const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
+    const adjective =
+      filteredAdjectives[Math.floor(Math.random() * filteredAdjectives.length)];
 
     combination += capitalizeFirstLetter
       ? adjective.charAt(0).toUpperCase() + adjective.slice(1) + delimiter
       : adjective + delimiter;
   }
 
+  const noun = filteredNouns[Math.floor(Math.random() * filteredNouns.length)];
   combination += capitalizeFirstLetter
-    ? animal.charAt(0).toUpperCase() + animal.slice(1)
-    : animal;
+    ? noun.charAt(0).toUpperCase() + noun.slice(1)
+    : noun;
+
   return combination;
 };
 

--- a/app/client-app/src/services/gfycat-style-urls.js
+++ b/app/client-app/src/services/gfycat-style-urls.js
@@ -23,9 +23,7 @@ const generateGfyCatStyleUrl = (
   const filteredAdjectives = adjectives.filter(
     (adjective) => !excludedBuitinWords[adjective]
   );
-  const filteredNouns = animals.filter(
-    (adjective) => !excludedBuitinWords[adjective]
-  );
+  const filteredNouns = animals.filter((noun) => !excludedBuitinWords[noun]);
 
   for (let i = 0; i < numAdjectives; i++) {
     const adjective =

--- a/app/client-app/src/services/gfycat-style-urls.js
+++ b/app/client-app/src/services/gfycat-style-urls.js
@@ -10,14 +10,14 @@ import animals from "./animals";
 import { toDictionary } from "./data-structures";
 
 const generateGfyCatStyleUrl = (
-  wordlist,
+  excludedBuiltins,
   numAdjectives,
   delimiter,
   capitalizeFirstLetter
 ) => {
   let combination = "";
 
-  const excludedBuitinWords = toDictionary(wordlist.excludedBuiltins, "word");
+  const excludedBuitinWords = toDictionary(excludedBuiltins, "word");
 
   // Filter adjectives array
   const filteredAdjectives = adjectives.filter(

--- a/app/client-app/src/services/gyfcat-style-urls.test.js
+++ b/app/client-app/src/services/gyfcat-style-urls.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import generateGfyCatStyleUrl from "./gfycat-style-urls";
+
+describe("generateGfyCatStyleUrl", () => {
+  it("should not include excluded built-in words in the string", () => {
+    const excludedBuiltins = ["lazy", "cat"];
+    const result = generateGfyCatStyleUrl(excludedBuiltins, 1, "", true);
+    expect(result.includes("Lazy")).toBe(false);
+    expect(result.includes("Cat")).toBe(false);
+  });
+
+  it("should throw an error for non-array excludedBuiltins", () => {
+    expect(() => generateGfyCatStyleUrl("not an array", 1, "", true)).toThrow();
+  });
+
+  it("should return only a noun when numAdjectives is 0", () => {
+    const result = generateGfyCatStyleUrl([], 0, "", true);
+    const words = result.split(/(?=[A-Z])/);
+    expect(words.length).toBe(1);
+  });
+
+  it("should return a string with the correct number of adjectives", () => {
+    const numAdjectives = 2;
+    const result = generateGfyCatStyleUrl([], numAdjectives, "", true);
+    const words = result.split(/(?=[A-Z])/);
+    expect(words.length - 1).toBe(numAdjectives); // -1 to not count the animal noun
+  });
+
+  it("should return a string with only one noun", () => {
+    const numAdjectives = 2;
+    const result = generateGfyCatStyleUrl([], numAdjectives, "", true);
+    const words = result.split(/(?=[A-Z])/);
+    expect(words.length - numAdjectives).toBe(1); // 1, because only one noun should be in the result string
+  });
+
+  it("should return a string with capitalized words if capitalizeFirstLetter is true", () => {
+    const result = generateGfyCatStyleUrl([], 1, "", true);
+    const words = result.split(/(?=[A-Z])/);
+    words.forEach((word) => {
+      expect(word[0]).toBe(word[0].toUpperCase());
+    });
+  });
+
+  it("should return a string with lowercase words if capitalizeFirstLetter is false", () => {
+    const result = generateGfyCatStyleUrl([], 1, "", false);
+    const words = result.split(" ");
+    words.forEach((word) => {
+      expect(word[0]).toBe(word[0].toLowerCase());
+    });
+  });
+
+  it("should return a string with correct delimiter", () => {
+    const delimiter = "-";
+    const result = generateGfyCatStyleUrl([], 1, delimiter, true);
+    expect(result.includes(delimiter)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR ensures that the Generated Ids do not include excluded built in words from wordlist by filtering them off

- generateGfyCatStyleUrl update to use excludedBuiltins 
- unit test for generateGfyCatStyleUrl

The following screenshot shows generated IDs when all animals (nouns) besides **Aardvark** are blocked 
![image](https://github.com/decsys/decsys/assets/90258816/69fcf74e-e02f-488a-aa9a-c8001e704e4e)