### PR TITLE
AB#113972: Mulitiple filters

### DIFF
--- a/app/client-app/src/app/pages/Wordlist/components/WordlistSortingAndFiltering.jsx
+++ b/app/client-app/src/app/pages/Wordlist/components/WordlistSortingAndFiltering.jsx
@@ -5,7 +5,7 @@ const WordlistSortingAndFilteringPanel = ({
   data,
   sorting,
   onSort,
-  filter,
+  filterConfig,
   setFilter,
 }) => {
   return (
@@ -27,10 +27,12 @@ const WordlistSortingAndFilteringPanel = ({
             />
           </HStack>
           <Input
-            placeholder="Search by Name"
+            placeholder="Search by Word"
             size="sm"
-            value={filter}
-            onChange={({ target: { value } }) => setFilter(value)}
+            value={filterConfig.wordContains}
+            onChange={({ target: { value } }) =>
+              setFilter("wordContains", value)
+            }
           />
         </VStack>
       )}

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -3,8 +3,10 @@ import { useSortingAndFiltering } from "hooks/useSortingAndFiltering";
 export const useWordlistSortingAndFiltering = (data) => {
   const filterers = {
     wordContains: "word",
-    minLengthIsMet: (value, filter) => value.word.length >= filter,
-    maxLengthIsNotExceeded: (value, filter) => value.word.length <= filter,
+    wordLengthMatches: (value, filter) => {
+      const [minLength, maxLength] = filter;
+      return value.word.length >= minLength && value.word.length <= maxLength;
+    },
     typeMatches: (value, filter) => {
       switch (filter) {
         case "Adjective":

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -7,6 +7,17 @@ export const useWordlistSortingAndFiltering = (data) => {
       !filter || filter.toLowerCase() === "all"
         ? true
         : value.type.toLowerCase() === filter.toLowerCase(),
+    exclusionStateMatches: (value, filter) => {
+      switch (filter) {
+        case "Excluded":
+          return value.isExcludedBuiltin;
+        case "Included":
+          return !value.isExcludedBuiltin;
+        case "All":
+        default:
+          return true;
+      }
+    },
 
     // other filterers go here...
   };

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -1,7 +1,17 @@
 import { useSortingAndFiltering } from "hooks/useSortingAndFiltering";
 
-export const useWordlistSortingAndFiltering = (data) =>
-  useSortingAndFiltering(data, "word", {
+export const useWordlistSortingAndFiltering = (data) => {
+  const filterers = {
+    wordContains: "word",
+    typeMatches: (value, filter) =>
+      !filter || filter.toLowerCase() === "all"
+        ? true
+        : value.type.toLowerCase() === filter.toLowerCase(),
+
+    // other filterers go here...
+  };
+
+  return useSortingAndFiltering(data, filterers, {
     initialSort: {
       key: "word",
     },
@@ -20,3 +30,4 @@ export const useWordlistSortingAndFiltering = (data) =>
     },
     storageKey: "wordlist",
   });
+};

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -18,8 +18,8 @@ export const useWordlistSortingAndFiltering = (data) => {
           return true;
       }
     },
-
-    // other filterers go here...
+    wordLengthIsInRange: (value, filter) =>
+      value.word.length >= filter[0] && value.word.length <= filter[1],
   };
 
   return useSortingAndFiltering(data, filterers, {

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -5,10 +5,17 @@ export const useWordlistSortingAndFiltering = (data) => {
     wordContains: "word",
     minLengthIsMet: (value, filter) => value.word.length >= filter,
     maxLengthIsNotExceeded: (value, filter) => value.word.length <= filter,
-    typeMatches: (value, filter) =>
-      !filter || filter.toLowerCase() === "all"
-        ? true
-        : value.type.toLowerCase() === filter.toLowerCase(),
+    typeMatches: (value, filter) => {
+      switch (filter) {
+        case "Adjective":
+          return value.type === "adjective";
+        case "Noun":
+          return value.type === "noun";
+        case "All":
+        default:
+          return true;
+      }
+    },
     exclusionStateMatches: (value, filter) => {
       switch (filter) {
         case "Excluded":

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -3,6 +3,8 @@ import { useSortingAndFiltering } from "hooks/useSortingAndFiltering";
 export const useWordlistSortingAndFiltering = (data) => {
   const filterers = {
     wordContains: "word",
+    minLengthIsMet: (value, filter) => value.word.length >= filter,
+    maxLengthIsNotExceeded: (value, filter) => value.word.length <= filter,
     typeMatches: (value, filter) =>
       !filter || filter.toLowerCase() === "all"
         ? true
@@ -18,8 +20,6 @@ export const useWordlistSortingAndFiltering = (data) => {
           return true;
       }
     },
-    minLengthIsMet: (value, filter) => value.word.length >= filter,
-    maxLengthIsNotExceeded: (value, filter) => value.word.length <= filter,
   };
 
   return useSortingAndFiltering(data, filterers, {

--- a/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
+++ b/app/client-app/src/app/pages/Wordlist/components/hooks/useWordlistSortingAndFiltering.js
@@ -18,8 +18,8 @@ export const useWordlistSortingAndFiltering = (data) => {
           return true;
       }
     },
-    wordLengthIsInRange: (value, filter) =>
-      value.word.length >= filter[0] && value.word.length <= filter[1],
+    minLengthIsMet: (value, filter) => value.word.length >= filter,
+    maxLengthIsNotExceeded: (value, filter) => value.word.length <= filter,
   };
 
   return useSortingAndFiltering(data, filterers, {

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -49,7 +49,7 @@ const Wordlist = () => {
   const [sliderValues, setSliderValues] = useState([1, 15]);
 
   const handleSliderChange = (values) => {
-    setSliderValues(values);
+    setFilter("wordLengthIsInRange", values);
   };
 
   const handleTypeChange = (value) => {
@@ -86,7 +86,7 @@ const Wordlist = () => {
                 getRadioProps={getExclusionRadioProps}
               />
               <WordLengthFilter
-                sliderValues={sliderValues}
+                sliderValues={filterConfig.wordLengthIsInRange}
                 handleSliderChange={handleSliderChange}
               />
             </VStack>

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -49,7 +49,9 @@ const Wordlist = () => {
   const [sliderValues, setSliderValues] = useState([1, 15]);
 
   const handleSliderChange = (values) => {
-    setFilter("wordLengthIsInRange", values);
+    setSliderValues(values);
+    setFilter("minLengthIsMet", values[0]);
+    setFilter("maxLengthIsNotExceeded", values[1]);
   };
 
   const handleTypeChange = (value) => {
@@ -86,7 +88,7 @@ const Wordlist = () => {
                 getRadioProps={getExclusionRadioProps}
               />
               <WordLengthFilter
-                sliderValues={filterConfig.wordLengthIsInRange}
+                sliderValues={sliderValues}
                 handleSliderChange={handleSliderChange}
               />
             </VStack>

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -44,7 +44,7 @@ const WordlistDisplay = ({ outputList, height, width, toggleExclude }) => {
 
 const Wordlist = () => {
   const { cards, toggleExclude } = useWordData();
-  const { sorting, onSort, outputList, filter, setFilter } =
+  const { sorting, onSort, outputList, filterConfig, setFilter } =
     useWordlistSortingAndFiltering(cards);
   const [sliderValues, setSliderValues] = useState([1, 15]);
 
@@ -52,11 +52,15 @@ const Wordlist = () => {
     setSliderValues(values);
   };
 
+  const handleTypeChange = (value) => {
+    setFilter("typeMatches", value);
+  };
+
   const { getRootProps: getTypeRootProps, getRadioProps: getTypeRadioProps } =
     useRadioGroup({
       name: "type",
       defaultValue: "All",
-      onChange: console.log,
+      onChange: handleTypeChange,
     });
 
   const {
@@ -91,7 +95,7 @@ const Wordlist = () => {
               data={cards}
               sorting={sorting}
               onSort={onSort}
-              filter={filter}
+              filterConfig={filterConfig}
               setFilter={setFilter}
             />
           </Flex>

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -50,8 +50,7 @@ const Wordlist = () => {
 
   const handleSliderChange = (values) => {
     setSliderValues(values);
-    setFilter("minLengthIsMet", values[0]);
-    setFilter("maxLengthIsNotExceeded", values[1]);
+    setFilter("wordLengthMatches", values);
   };
 
   const { getRootProps: getTypeRootProps, getRadioProps: getTypeRadioProps } =

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -54,15 +54,11 @@ const Wordlist = () => {
     setFilter("maxLengthIsNotExceeded", values[1]);
   };
 
-  const handleTypeChange = (value) => {
-    setFilter("typeMatches", value);
-  };
-
   const { getRootProps: getTypeRootProps, getRadioProps: getTypeRadioProps } =
     useRadioGroup({
       name: "type",
       defaultValue: "All",
-      onChange: handleTypeChange,
+      onChange: setFilter("typeMatches", value),
     });
 
   const {

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -58,7 +58,7 @@ const Wordlist = () => {
     useRadioGroup({
       name: "type",
       defaultValue: "All",
-      onChange: setFilter("typeMatches", value),
+      onChange: (value) => setFilter("typeMatches", value),
     });
 
   const {

--- a/app/client-app/src/app/pages/Wordlist/index.jsx
+++ b/app/client-app/src/app/pages/Wordlist/index.jsx
@@ -69,7 +69,7 @@ const Wordlist = () => {
   } = useRadioGroup({
     name: "exclusion",
     defaultValue: "All",
-    onChange: console.log,
+    onChange: (value) => setFilter("exclusionStateMatches", value),
   });
   const typeGroup = getTypeRootProps();
   const exclusionGroup = getExclusionRootProps();

--- a/app/client-app/src/hooks/getFilteredLookup.test.js
+++ b/app/client-app/src/hooks/getFilteredLookup.test.js
@@ -74,4 +74,15 @@ describe("getFilteredLookup", () => {
       { name: "Anna", age: 30, isEmployed: true },
     ]);
   });
+
+  it("Should apply multiple filters correctly", () => {
+    const filterConfig = { age: 30, isEmployed: true };
+    const filterers = {
+      age: (value, filter) => value.age === filter,
+      isEmployed: "isEmployed",
+    };
+
+    const output = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(output).toEqual([{ name: "Anna", age: 30, isEmployed: true }]);
+  });
 });

--- a/app/client-app/src/hooks/getFilteredLookup.test.js
+++ b/app/client-app/src/hooks/getFilteredLookup.test.js
@@ -1,0 +1,77 @@
+import { expect, it, describe } from "vitest";
+import { getFilteredLookup } from "./useSortingAndFiltering";
+
+describe("getFilteredLookup", () => {
+  const mockData = [
+    { name: "James", age: 30, isEmployed: false },
+    { name: "Anna", age: 30, isEmployed: true },
+    { name: "Robert", age: 40, isEmployed: true },
+    { name: "Michael", age: 50, isEmployed: true },
+    { name: "John", age: 60, isEmployed: false },
+  ];
+
+  it("Should return the original array when filterConfig is empty", () => {
+    const filterConfig = {};
+    const filterers = {};
+
+    const output = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(output).toEqual(mockData);
+  });
+
+  it("filters based on age 30", () => {
+    const filterConfig = { age: 30 };
+    const filterers = { age: (value, filter) => value.age === filter };
+
+    const output = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(output).toEqual([
+      { name: "James", age: 30, isEmployed: false },
+      { name: "Anna", age: 30, isEmployed: true },
+    ]);
+  });
+
+  it("filters based on names that start with J", () => {
+    const filterConfig = { name: "^J" };
+    const filterers = { name: "name" };
+
+    const result = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(result).toEqual([
+      { name: "James", age: 30, isEmployed: false },
+      { name: "John", age: 60, isEmployed: false },
+    ]);
+  });
+
+  it("filters based on names that contains the letter a", () => {
+    const filterConfig = { name: "a" };
+    const filterers = { name: "name" };
+
+    const result = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(result).toEqual([
+      { name: "James", age: 30, isEmployed: false },
+      { name: "Anna", age: 30, isEmployed: true },
+      { name: "Michael", age: 50, isEmployed: true },
+    ]);
+  });
+
+  it("filters based on employment status", () => {
+    const filterConfig = { isEmployed: true };
+    const filterers = { isEmployed: "isEmployed" };
+
+    const result = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(result).toEqual([
+      { name: "Anna", age: 30, isEmployed: true },
+      { name: "Robert", age: 40, isEmployed: true },
+      { name: "Michael", age: 50, isEmployed: true },
+    ]);
+  });
+
+  it("filters based on exact age", () => {
+    const filterConfig = { age: 30 };
+    const filterers = { age: (value, filter) => value.age === filter };
+
+    const result = getFilteredLookup(mockData, filterConfig, filterers);
+    expect(result).toEqual([
+      { name: "James", age: 30, isEmployed: false },
+      { name: "Anna", age: 30, isEmployed: true },
+    ]);
+  });
+});

--- a/app/client-app/src/hooks/useSortingAndFiltering.js
+++ b/app/client-app/src/hooks/useSortingAndFiltering.js
@@ -113,7 +113,7 @@ export const useSortingAndFiltering = (
     Object.keys(filterers).reduce(
       (acc, key) => ({
         ...acc,
-        [key]: key === "wordLengthIsInRange" ? [1, 15] : "",
+        [key]: "",
       }),
       {}
     )

--- a/app/client-app/src/hooks/useSortingAndFiltering.js
+++ b/app/client-app/src/hooks/useSortingAndFiltering.js
@@ -93,11 +93,12 @@ export const useSortingAndFiltering = (
     Object.keys(filterers).reduce(
       (acc, key) => ({
         ...acc,
-        [key]: key.includes("Match") ? { test: "" } : "",
+        [key]: key === "wordLengthIsInRange" ? [1, 15] : "",
       }),
       {}
     )
   );
+
   const [outputList, setOutputList] = useState([]);
   // update the sorted list appropriately
   useEffect(() => {

--- a/app/client-app/src/hooks/useSortingAndFiltering.js
+++ b/app/client-app/src/hooks/useSortingAndFiltering.js
@@ -49,7 +49,8 @@ const getSortedLookup = (input, key, asc, sorters) =>
  * on the `filter` string. If no filter is specified, the full input list is returned.
  *
  * @param {object[]} input The source list of objects.
- * @param {object} filterConfig The configuration object for filters. The keys should match with filterers and values should be filter value.
+ * @param {object} filterConfig An object holding the current state or values of the filters.
+ * The keys in this object should match the keys in the 'filterers' object.
  * For example: { nameContains: "John" }
  *
  * @param {object} filterers

--- a/app/client-app/src/hooks/useSortingAndFiltering.js
+++ b/app/client-app/src/hooks/useSortingAndFiltering.js
@@ -77,7 +77,7 @@ export const getFilteredLookup = (input, filterConfig = {}, filterers = {}) =>
     })
   );
 
-const storageKeyPrefix = "sargassure.sorting";
+const storageKeyPrefix = "decsys.sorting";
 
 /**
  * A custom hook that manages sorting and filtering operations for a list of objects.


### PR DESCRIPTION
This PR update supports multiple filtering to take place

- _getFilteredLookup_ update to handle filterer being a function or a string
- _filterConfig_ state initialised to an objects
- New fitlerers
  1. _exclusionStateMatches_: This filterer filters words based on whether they are excluded or included.
  2. _typeMatches_: This filterer shows words if their type matches a given filter.
  3. _minLengthIsMet_, _maxLengthIsNotExceeded_: These filterers filter words depending on whether their length falls within a given range.

- Documents updates
- Unit tests for _getFilteredLookup_

Example shows words that are adjective and excluded (blocked)
![Screenshot 2023-07-14 at 09 45 37](https://github.com/decsys/decsys/assets/90258816/0dba0247-8fed-497f-a1bb-efdc8e99cd0d)

