### PR TITLE
AB#109838: Webhook Hashing 

### DIFF
--- a/app/Decsys/Data/Entities/Mongo/Webhook.cs
+++ b/app/Decsys/Data/Entities/Mongo/Webhook.cs
@@ -7,7 +7,7 @@ public class Webhook
     public int Id { get; set; }
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string? SecretHash { get; set; }
+    public string? Secret { get; set; }
     public bool VerifySsl { get; set; }
 
     public List<TriggerCriteria> TriggerCriteria { get; set; } = new List<TriggerCriteria>();

--- a/app/Decsys/Models/Webhooks/WebhookModel.cs
+++ b/app/Decsys/Models/Webhooks/WebhookModel.cs
@@ -4,7 +4,7 @@ public class WebhookModel
 {
     public int SurveyId { get; set; }
     public string CallbackUrl { get; set; } = string.Empty;
-    public string? SecretHash { get; set; }
+    public string? Secret { get; set; }
     public bool VerifySsl { get; set; }
     
     /// <summary>

--- a/app/Decsys/Repositories/Mongo/WebhookRepository.cs
+++ b/app/Decsys/Repositories/Mongo/WebhookRepository.cs
@@ -27,7 +27,7 @@ public class WebhookRepository : IWebhookRepository
         {
             SurveyId = webhook.SurveyId,
             CallbackUrl = webhook.CallbackUrl,
-            SecretHash = webhook.SecretHash,
+            Secret = webhook.Secret,
             VerifySsl = webhook.VerifySsl,
             TriggerCriteria = webhook.TriggerCriteria
         };
@@ -44,7 +44,7 @@ public class WebhookRepository : IWebhookRepository
                 {
                     SurveyId = x.SurveyId,
                     CallbackUrl = x.CallbackUrl,
-                    SecretHash = x.SecretHash,
+                    Secret = x.Secret,
                     VerifySsl = x.VerifySsl,
                     TriggerCriteria = x.TriggerCriteria
                 })).ToList();

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -92,12 +92,14 @@ public class WebhookService
 
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         
-        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(webhook.Secret));
-        
-        if (webhook.Secret is not null)   content.Headers.Add("X-Decsys-Signature",
-            Encoding.UTF8.GetString(
-                hmac.ComputeHash(
-                    Encoding.UTF8.GetBytes(json))));
+         if (webhook.Secret is not null)
+         {
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(webhook.Secret));
+            content.Headers.Add("X-Decsys-Signature",
+                Encoding.UTF8.GetString(
+                    hmac.ComputeHash(
+                        Encoding.UTF8.GetBytes(json))));
+          }
 
         await _client.PostAsync(webhook.CallbackUrl, content);
     }

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -85,7 +85,7 @@ public class WebhookService
     /// Posts webhook data to a given URL.
     /// </summary>
     /// <param name="payload">Payload to Post</param>
-    /// <param name="webhook">Webhook to Post to</param>
+    /// <param name="webhook">An instance of WebhookModel containing the CallbackUrl and a Secret for HMACSHA256 hashing</param>
     private async Task SendWebhook(WebhookModel webhook, PayloadModel payload)
     {
         var json = JsonConvert.SerializeObject(payload);


### PR DESCRIPTION
Changes to use HMAC Sha256 to compute the Hash for sending webhooks