### PR TITLE
AB#116440: Webhook Secret 

### DIFF
--- a/app/Decsys/Models/Webhooks/ViewWebhook.cs
+++ b/app/Decsys/Models/Webhooks/ViewWebhook.cs
@@ -1,0 +1,15 @@
+namespace Decsys.Models.Webhooks;
+
+public class ViewWebhook
+{
+    
+    public int SurveyId { get; set; }
+    public string CallbackUrl { get; set; } = string.Empty;
+    public bool HasSecret { get; set; }
+    public bool VerifySsl { get; set; }
+    /// <summary>
+    /// The trigger criteria to test against.
+    /// </summary>
+    public TriggerCriteria TriggerCriteria { get; set; } = new();
+
+}

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -29,8 +29,21 @@ public class WebhookService
         => _webhooks.Create(model);
     
     
-    public List<WebhookModel> List(int surveyId)
-        => _webhooks.List(surveyId);
+    public List<ViewWebhook> List(int surveyId)
+    {
+        var webhookModels = _webhooks.List(surveyId);
+
+        var webhookViewModels = webhookModels.Select(w => new ViewWebhook
+        {
+            SurveyId = w.SurveyId,
+            CallbackUrl = w.CallbackUrl,
+            HasSecret = !string.IsNullOrEmpty(w.Secret),
+            VerifySsl = w.VerifySsl,
+            TriggerCriteria = w.TriggerCriteria
+        }).ToList();
+
+        return webhookViewModels;
+    }
     
     /// <summary>
     /// Triggers webhooks from a given payload.


### PR DESCRIPTION
The changes in this PR ensures secrets can't be revealed once set

- A new ViewWebhook added which indicates whether a secret exists or not
- List method now maps each WebhookModel to a ViewWebhook, hiding the secret's actual content 