### PR TITLE
AB#105222: Editing a Webhook

### DIFF
--- a/app/Decsys/Controllers/WebhooksController.cs
+++ b/app/Decsys/Controllers/WebhooksController.cs
@@ -76,6 +76,16 @@ public class WebhooksController : ControllerBase
         return Ok(webhooks);
     }
     
+    [HttpPut("{id}")]
+    [SwaggerOperation("Edit a webhook by its ID")]
+    [SwaggerResponse(200, "Webhook successfully updated")]
+    public IActionResult Edit(string id, WebhookModel model)
+    {
+        var newWebhook = _webhooks.Edit(id, model);
+        return Ok(newWebhook);  
+    }
+
+
     [HttpDelete("{id}")]
     [SwaggerOperation("Delete a webhook by its ID")]
     [SwaggerResponse(204, "Webhook successfully deleted")]

--- a/app/Decsys/Controllers/WebhooksController.cs
+++ b/app/Decsys/Controllers/WebhooksController.cs
@@ -75,16 +75,29 @@ public class WebhooksController : ControllerBase
         var webhooks = _webhooks.List(surveyId);
         return Ok(webhooks);
     }
-    
+
     [HttpPut("{id}")]
     [SwaggerOperation("Edit a webhook by its ID")]
     [SwaggerResponse(200, "Webhook successfully updated")]
+    [SwaggerResponse(400, "Invalid model provided")]
+    [SwaggerResponse(404, "No webhook found with the specified ID and survey ID")]
     public IActionResult Edit(string id, WebhookModel model)
     {
-        var newWebhook = _webhooks.Edit(id, model);
-        return Ok(newWebhook);  
-    }
+        if (!ModelState.IsValid) 
+        {
+            return BadRequest("Invalid model provided.");
+        }
 
+        try 
+        {
+            var newWebhook = _webhooks.Edit(id, model);
+            return Ok(newWebhook);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
 
     [HttpDelete("{id}")]
     [SwaggerOperation("Delete a webhook by its ID")]

--- a/app/Decsys/Repositories/Contracts/IWebhookRepository.cs
+++ b/app/Decsys/Repositories/Contracts/IWebhookRepository.cs
@@ -31,4 +31,6 @@ public interface IWebhookRepository
     /// <param name="webhookId">The id of the webhook to delete.</param>
     void Delete(string webhookId);
 
+
+    ViewWebhook Edit(string webhookId, WebhookModel model);
 }

--- a/app/Decsys/Repositories/LiteDb/LiteDbWebhookRepository.cs
+++ b/app/Decsys/Repositories/LiteDb/LiteDbWebhookRepository.cs
@@ -23,6 +23,11 @@ public class LiteDbWebhookRepository : IWebhookRepository
         throw new NotImplementedException();
     }
     
+    public ViewWebhook Edit(string webhookId, WebhookModel model)
+    {
+        throw new NotImplementedException();
+    }
+    
     public void Delete(string webhookId)
     {
         throw new NotImplementedException();

--- a/app/Decsys/Repositories/Mongo/WebhookRepository.cs
+++ b/app/Decsys/Repositories/Mongo/WebhookRepository.cs
@@ -67,6 +67,32 @@ public class WebhookRepository : IWebhookRepository
                     Id = x.Id.ToString()
                 })).ToList();
 
+    public ViewWebhook Edit(string webhookId, WebhookModel model)
+    {
+        var objectId = new ObjectId(webhookId);
+        var webhook = _webhooks.Find(x => x.Id == objectId).FirstOrDefault();
+        
+        webhook.CallbackUrl = model.CallbackUrl;
+        webhook.VerifySsl = model.VerifySsl;
+        webhook.TriggerCriteria = model.TriggerCriteria;
+        if (model.Secret != null)
+        {
+            webhook.Secret = model.Secret;
+        }
+        
+        _webhooks.ReplaceOne(x => x.Id == objectId, webhook);
+        
+        return new ViewWebhook
+        {
+            Id = webhook.Id.ToString(),
+            SurveyId = webhook.SurveyId,
+            CallbackUrl = webhook.CallbackUrl,
+            HasSecret = !string.IsNullOrEmpty(webhook.Secret),
+            VerifySsl = webhook.VerifySsl,
+            TriggerCriteria = webhook.TriggerCriteria
+        };
+    }
+
     public void Delete(string webhookId)
     {
         var objectId = new ObjectId(webhookId);

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -147,8 +147,18 @@ public class WebhookService
     }
     
     public ViewWebhook Edit(string webhookId, WebhookModel model)
-        => _webhooks.Edit(webhookId, model);
-    
+    {
+        var existingWebhook = _webhooks.Get(webhookId);
+        if (existingWebhook == null)
+            throw new KeyNotFoundException($"Webhook with ID {webhookId} not found.");
+
+        if (existingWebhook.SurveyId != model.SurveyId)
+            throw new KeyNotFoundException($"No webhook found with ID {webhookId} matching the provided survey ID.");
+
+        return _webhooks.Edit(webhookId, model);
+    }
+
+
     /// <summary>
     /// Deletes a webhook by its ID.
     /// </summary>

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -48,6 +48,7 @@ public class WebhookService
         return webhookViewModels;
     }
     
+    
     /// <summary>
     /// Triggers webhooks from a given payload.
     /// </summary>
@@ -144,7 +145,9 @@ public class WebhookService
          }
          await _client.PostAsync(webhook.CallbackUrl, content);
     }
-
+    
+    public ViewWebhook Edit(string webhookId, WebhookModel model)
+        => _webhooks.Edit(webhookId, model);
     
     /// <summary>
     /// Deletes a webhook by its ID.


### PR DESCRIPTION
This PR introduces functionality to edit an existing webhook 

**Key Changes:**
- Repository method where secret is only updated once a new value is provided.
- Service method where Error thrown if survey ID is mismatched for a webhook.
- Controller Api Endpoint with Swagger annotations.