### PR TITLE
AB#105221: Webhook Edit

### DIFF
--- a/app/client-app/src/api/webhooks.js
+++ b/app/client-app/src/api/webhooks.js
@@ -62,3 +62,11 @@ export const deleteWebhook = async (webhookId) => {
   );
   return response.data;
 };
+
+export const getWebhook = async (webhookId) => {
+  const response = await axios.get(
+    `/api/webhooks/${webhookId}`,
+    withHeaders(await authorization_BearerToken())
+  );
+  return response.data;
+};

--- a/app/client-app/src/api/webhooks.js
+++ b/app/client-app/src/api/webhooks.js
@@ -6,7 +6,7 @@ import {
 } from "./helpers";
 import useSWR from "swr";
 
-export const createWebhook = async (
+export const constructWebhookPayload = (
   surveyId,
   callbackUrl,
   secret,
@@ -25,18 +25,68 @@ export const createWebhook = async (
     eventTypes.PAGE_NAVIGATION = null;
   }
 
+  return {
+    surveyId,
+    callbackUrl,
+    secret,
+    verifySsl,
+    triggerCriteria: {
+      eventTypes,
+      hasCustomTriggers,
+    },
+  };
+};
+
+export const createWebhook = async (
+  surveyId,
+  callbackUrl,
+  secret,
+  verifySsl,
+  sourcePages,
+  hasCustomTriggers,
+  pageNavigation
+) => {
+  const payload = constructWebhookPayload(
+    surveyId,
+    callbackUrl,
+    secret,
+    verifySsl,
+    sourcePages,
+    hasCustomTriggers,
+    pageNavigation
+  );
+
   const response = await axios.post(
     "/api/webhooks",
-    {
-      surveyId,
-      callbackUrl,
-      secret,
-      verifySsl,
-      triggerCriteria: {
-        eventTypes,
-        hasCustomTriggers,
-      },
-    },
+    payload,
+    withHeaders(await authorization_BearerToken())
+  );
+  return response.data;
+};
+
+export const updateWebhook = async (
+  webhookId,
+  surveyId,
+  callbackUrl,
+  secret,
+  verifySsl,
+  sourcePages,
+  hasCustomTriggers,
+  pageNavigation
+) => {
+  const payload = constructWebhookPayload(
+    surveyId,
+    callbackUrl,
+    secret,
+    verifySsl,
+    sourcePages,
+    hasCustomTriggers,
+    pageNavigation
+  );
+
+  const response = await axios.put(
+    `/api/webhooks/${webhookId}`,
+    payload,
     withHeaders(await authorization_BearerToken())
   );
   return response.data;

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
@@ -40,22 +40,6 @@ const WebhookActionCard = ({ webhook, onEditWebhook }) => {
     }
   };
 
-  // const handleEdit = async () => {
-  //   try {
-  //     const webhookData = await getWebhook(webhook.id);
-  //     console.log(webhookData);
-  //   } catch (error) {
-  //     toast({
-  //       title: "Error Fetching Webhook",
-  //       description:
-  //         error.message || "There was an error fetching the webhook details.",
-  //       status: "error",
-  //       duration: 5000,
-  //       isClosable: true,
-  //     });
-  //   }
-  //};
-
   const handleEdit = () => {
     onEditWebhook(webhook);
   };

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
@@ -9,9 +9,10 @@ import {
   Icon,
   useToast,
 } from "@chakra-ui/react";
-import { FaTrash, FaFilter } from "react-icons/fa";
+import { FaTrash, FaFilter, FaEdit } from "react-icons/fa";
 import { ActionCard } from "components/shared/ActionCard";
 import { deleteWebhook, useWebhook } from "api/webhooks";
+import { getWebhook } from "api/webhooks";
 
 const WebhookActionCard = ({ webhook }) => {
   const { mutate } = useWebhook(webhook.surveyId);
@@ -39,6 +40,22 @@ const WebhookActionCard = ({ webhook }) => {
     }
   };
 
+  const handleEdit = async () => {
+    try {
+      const webhookData = await getWebhook(webhook.id);
+      console.log(webhookData);
+    } catch (error) {
+      toast({
+        title: "Error Fetching Webhook",
+        description:
+          error.message || "There was an error fetching the webhook details.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
   return (
     <ActionCard
       title={
@@ -51,6 +68,13 @@ const WebhookActionCard = ({ webhook }) => {
             size="sm"
             icon={<FaTrash />}
             onClick={handleDelete}
+          />
+          <IconButton
+            colorScheme="blue"
+            size="sm"
+            icon={<FaEdit />}
+            onClick={handleEdit}
+            mr={2}
           />
         </Flex>
       }

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Flex,
   Heading,
   Text,
@@ -12,7 +11,6 @@ import {
 import { FaTrash, FaFilter, FaEdit } from "react-icons/fa";
 import { ActionCard } from "components/shared/ActionCard";
 import { deleteWebhook, useWebhook } from "api/webhooks";
-import { getWebhook } from "api/webhooks";
 
 const WebhookActionCard = ({ webhook, onEditWebhook }) => {
   const { mutate } = useWebhook(webhook.surveyId);

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
@@ -51,19 +51,21 @@ const WebhookActionCard = ({ webhook, onEditWebhook }) => {
           <Heading as="h4" size="md" wordBreak="break-all">
             {webhook.callbackUrl}
           </Heading>
-          <IconButton
-            colorScheme="red"
-            size="sm"
-            icon={<FaTrash />}
-            onClick={handleDelete}
-          />
-          <IconButton
-            colorScheme="blue"
-            size="sm"
-            icon={<FaEdit />}
-            onClick={handleEdit}
-            mr={2}
-          />
+          <Flex width="65px">
+            <IconButton
+              colorScheme="blue"
+              size="sm"
+              icon={<FaEdit />}
+              onClick={handleEdit}
+              mr={2}
+            />
+            <IconButton
+              colorScheme="red"
+              size="sm"
+              icon={<FaTrash />}
+              onClick={handleDelete}
+            />
+          </Flex>
         </Flex>
       }
     >

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookActionCard.jsx
@@ -14,7 +14,7 @@ import { ActionCard } from "components/shared/ActionCard";
 import { deleteWebhook, useWebhook } from "api/webhooks";
 import { getWebhook } from "api/webhooks";
 
-const WebhookActionCard = ({ webhook }) => {
+const WebhookActionCard = ({ webhook, onEditWebhook }) => {
   const { mutate } = useWebhook(webhook.surveyId);
   const toast = useToast();
   const handleDelete = async () => {
@@ -40,20 +40,24 @@ const WebhookActionCard = ({ webhook }) => {
     }
   };
 
-  const handleEdit = async () => {
-    try {
-      const webhookData = await getWebhook(webhook.id);
-      console.log(webhookData);
-    } catch (error) {
-      toast({
-        title: "Error Fetching Webhook",
-        description:
-          error.message || "There was an error fetching the webhook details.",
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
+  // const handleEdit = async () => {
+  //   try {
+  //     const webhookData = await getWebhook(webhook.id);
+  //     console.log(webhookData);
+  //   } catch (error) {
+  //     toast({
+  //       title: "Error Fetching Webhook",
+  //       description:
+  //         error.message || "There was an error fetching the webhook details.",
+  //       status: "error",
+  //       duration: 5000,
+  //       isClosable: true,
+  //     });
+  //   }
+  //};
+
+  const handleEdit = () => {
+    onEditWebhook(webhook);
   };
 
   return (

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -33,8 +33,9 @@ import LightHeading from "components/core/LightHeading";
 import { generateWebhookSecret } from "api/webhooks";
 import ConfirmationModal from "./ConfirmationModal";
 
-const WebhookForm = ({ isOpen, onClose, onSubmit }) => {
-  const finalRef = useRef(null);
+const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
+  const isEditMode = webhook?.id != null;
+  console.log(isEditMode);
   const toast = useToast();
   const {
     isOpen: isConfirmationOpen,
@@ -57,21 +58,31 @@ const WebhookForm = ({ isOpen, onClose, onSubmit }) => {
     setFieldValue("secret", newSecret);
     onConfirmationClose();
   };
+
   return (
-    <Modal finalFocusRef={finalRef} isOpen={isOpen} size="xl" onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Create a Webhook</ModalHeader>
+        <ModalHeader>
+          {isEditMode ? "Edit Webhook" : "Create a Webhook"}
+        </ModalHeader>
         <ModalCloseButton />
+
         <Formik
           initialValues={{
-            url: "",
-            secret: "",
-            verifySsl: true,
-            eventTrigger: "allEvents",
-            sourcePages: [],
-            hasCustomTriggers: false,
-            pageNavigation: true,
+            url: webhook?.callbackUrl || "",
+            secret: "", //TODO: Secrets
+            verifySsl: webhook?.verifySsl || true,
+            eventTrigger: webhook?.triggerCriteria?.hasCustomTriggers
+              ? "customEvents"
+              : "allEvents",
+            sourcePages:
+              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION || [],
+            hasCustomTriggers:
+              webhook?.triggerCriteria?.hasCustomTriggers || false,
+            pageNavigation:
+              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION?.length >
+                0 || false,
           }}
           onSubmit={(values) => {
             if (values.eventTrigger === "customEvents") {
@@ -226,7 +237,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit }) => {
                       </Accordion>
                     )}
                   </FieldArray>
-                )}
+                )}{" "}
                 <ModalFooter>
                   <Button colorScheme="red" mr={3} onClick={onClose}>
                     Cancel

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -114,11 +114,10 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                   />
                   {webhook?.hasSecret && (
                     <Alert status="warning" mt={4}>
-                      <AlertIcon />
-                      <AlertTitle mr={2}>Warning!</AlertTitle>
                       <AlertDescription>
-                        This webhook has a secret. Changing it may disrupt
-                        services dependent on it.
+                        If you've lost or forgotten this secret, you can change
+                        it, but be aware that any integrations using this secret
+                        will need to be updated.
                       </AlertDescription>
                     </Alert>
                   )}
@@ -141,7 +140,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                         handleGenerateSecret(values, setFieldValue)
                       }
                     >
-                      Generate Secret
+                      {webhook?.hasSecret ? "Change Sceret" : "Generate Secret"}
                     </Button>
                   </HStack>
                 </VStack>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -78,7 +78,7 @@ const SecretField = ({
                         </AlertTitle>
                       </HStack>
                       <AlertDescription>
-                        To retain a secret, please input a new value. An empty
+                        To change the secret, please input a new value. An empty
                         field signifies the removal of the current secret. For
                         continuity, you may cancel the editing process and
                         retain the existing secret.

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -71,7 +71,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
         <Formik
           initialValues={{
             url: webhook?.callbackUrl || "",
-            secret: "", // TODO
+            secret: webhook?.hasSecret ? "" : "",
             verifySsl: webhook?.verifySsl || true,
             eventTrigger: webhook?.triggerCriteria?.hasCustomTriggers
               ? "customEvents"
@@ -112,10 +112,24 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     header="Header"
                     size="sm"
                   />
+                  {webhook?.hasSecret && (
+                    <Alert status="warning" mt={4}>
+                      <AlertIcon />
+                      <AlertTitle mr={2}>Warning!</AlertTitle>
+                      <AlertDescription>
+                        This webhook has a secret. Changing it may disrupt
+                        services dependent on it.
+                      </AlertDescription>
+                    </Alert>
+                  )}
                   <HStack w="100%">
                     <TextField
                       name="secret"
-                      placeholder="Secret"
+                      placeholder={
+                        webhook?.hasSecret
+                          ? "Hidden due to security reasons"
+                          : "Secret"
+                      }
                       header="Header"
                       size="sm"
                     />

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -35,7 +35,7 @@ import ConfirmationModal from "./ConfirmationModal";
 
 const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
   const isEditMode = webhook?.id != null;
-  console.log(isEditMode);
+  console.log(webhook);
   const toast = useToast();
   const {
     isOpen: isConfirmationOpen,
@@ -71,18 +71,19 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
         <Formik
           initialValues={{
             url: webhook?.callbackUrl || "",
-            secret: "", //TODO: Secrets
+            secret: "", // TODO
             verifySsl: webhook?.verifySsl || true,
             eventTrigger: webhook?.triggerCriteria?.hasCustomTriggers
               ? "customEvents"
               : "allEvents",
-            sourcePages:
-              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION || [],
+            sourcePages: (
+              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION || []
+            ).map((item) => item.sourcePage),
             hasCustomTriggers:
               webhook?.triggerCriteria?.hasCustomTriggers || false,
             pageNavigation:
-              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION?.length >
-                0 || false,
+              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION &&
+              webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION.length > 0,
           }}
           onSubmit={(values) => {
             if (values.eventTrigger === "customEvents") {

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Formik, Form, Field, FieldArray } from "formik";
 import {
   Modal,
@@ -34,12 +34,16 @@ import { generateWebhookSecret } from "api/webhooks";
 import ConfirmationModal from "./ConfirmationModal";
 
 const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
-  console.log(webhook);
   const toast = useToast();
   const isEditMode = webhook?.id != null;
-  const [editSecret, setEditSecret] = useState(
-    !isEditMode || !webhook?.hasSecret
-  );
+  const [editSecret, setEditSecret] = useState(!isEditMode);
+
+  useEffect(() => {
+    if (isOpen && isEditMode) {
+      setEditSecret(false);
+    }
+  }, [isOpen, isEditMode]);
+
   const {
     isOpen: isConfirmationOpen,
     onOpen: onConfirmationOpen,
@@ -120,45 +124,39 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     header="Header"
                     size="sm"
                   />
-                  {/* Edit Secret behavior in edit mode */}
+                  {/* Edit mode */}
                   {isEditMode && (
                     <>
-                      {/* Show this advisory message only if editSecret is true */}
-                      {editSecret && (
-                        <Alert status="info" mt={4}>
-                          <AlertDescription>
-                            To retain a secret, please input a new value. An
-                            empty field signifies the removal of the current
-                            secret. For continuity, you may cancel the editing
-                            process and retain the existing secret.
-                          </AlertDescription>
-                        </Alert>
-                      )}
-
-                      {/* Show secret input and generate secret button when editSecret is true */}
-                      {editSecret && (
-                        <HStack w="100%">
-                          <TextField
-                            name="secret"
-                            placeholder="Secret"
-                            header="Header"
-                            size="sm"
-                          />
-                          <Button
-                            size="sm"
-                            colorScheme="teal"
-                            w="40%"
-                            onClick={() =>
-                              handleGenerateSecret(values, setFieldValue)
-                            }
-                          >
-                            Generate Secret
-                          </Button>
-                        </HStack>
-                      )}
-
-                      {/* When editSecret is false, show the Edit Secret button */}
-                      {!editSecret && (
+                      {editSecret ? (
+                        <>
+                          <Alert status="info" mt={4}>
+                            <AlertDescription>
+                              To retain a secret, please input a new value. An
+                              empty field signifies the removal of the current
+                              secret. For continuity, you may cancel the editing
+                              process and retain the existing secret.
+                            </AlertDescription>
+                          </Alert>
+                          <HStack w="100%">
+                            <TextField
+                              name="secret"
+                              placeholder="Secret"
+                              header="Header"
+                              size="sm"
+                            />
+                            <Button
+                              size="sm"
+                              colorScheme="teal"
+                              w="40%"
+                              onClick={() =>
+                                handleGenerateSecret(values, setFieldValue)
+                              }
+                            >
+                              Generate Secret
+                            </Button>
+                          </HStack>
+                        </>
+                      ) : (
                         <>
                           <Alert status="warning" mt={4}>
                             <AlertDescription>
@@ -178,7 +176,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     </>
                   )}
 
-                  {/* Generate secret button in create mode */}
+                  {/* Create Mode */}
                   {!isEditMode && (
                     <HStack w="100%">
                       <TextField

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -120,8 +120,66 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     header="Header"
                     size="sm"
                   />
+                  {/* Edit Secret behavior in edit mode */}
+                  {isEditMode && (
+                    <>
+                      {/* Show this advisory message only if editSecret is true */}
+                      {editSecret && (
+                        <Alert status="info" mt={4}>
+                          <AlertDescription>
+                            To retain a secret, please input a new value. An
+                            empty field signifies the removal of the current
+                            secret. For continuity, you may cancel the editing
+                            process and retain the existing secret.
+                          </AlertDescription>
+                        </Alert>
+                      )}
 
-                  {(!isEditMode || editSecret) && (
+                      {/* Show secret input and generate secret button when editSecret is true */}
+                      {editSecret && (
+                        <HStack w="100%">
+                          <TextField
+                            name="secret"
+                            placeholder="Secret"
+                            header="Header"
+                            size="sm"
+                          />
+                          <Button
+                            size="sm"
+                            colorScheme="teal"
+                            w="40%"
+                            onClick={() =>
+                              handleGenerateSecret(values, setFieldValue)
+                            }
+                          >
+                            Generate Secret
+                          </Button>
+                        </HStack>
+                      )}
+
+                      {/* When editSecret is false, show the Edit Secret button */}
+                      {!editSecret && (
+                        <>
+                          <Alert status="warning" mt={4}>
+                            <AlertDescription>
+                              If you've lost or forgotten this secret, you can
+                              change it, but be aware that any integrations
+                              using this secret will need to be updated.
+                            </AlertDescription>
+                          </Alert>
+                          <Button
+                            onClick={() => setEditSecret(true)}
+                            colorScheme="teal"
+                          >
+                            Edit Secret
+                          </Button>
+                        </>
+                      )}
+                    </>
+                  )}
+
+                  {/* Generate secret button in create mode */}
+                  {!isEditMode && (
                     <HStack w="100%">
                       <TextField
                         name="secret"
@@ -140,26 +198,6 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                         Generate Secret
                       </Button>
                     </HStack>
-                  )}
-
-                  {isEditMode && webhook?.hasSecret && !editSecret && (
-                    <>
-                      <Alert status="warning" mt={4}>
-                        <AlertDescription>
-                          If you've lost or forgotten this secret, you can
-                          change it, but be aware that any integrations using
-                          this secret will need to be updated.
-                        </AlertDescription>
-                      </Alert>
-                      <Button
-                        onClick={() => {
-                          setFieldValue("secret", ""); // Optionally clear the secret value, or keep it if desired
-                          setEditSecret(true);
-                        }}
-                      >
-                        Edit Secret
-                      </Button>
-                    </>
                   )}
                 </VStack>
                 <HStack pt="2">

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -69,12 +69,12 @@ const SecretField = ({
             <>
               {editSecret ? (
                 <>
-                  <Alert status="warning" mt={4}>
+                  <Alert status="info" mt={4}>
                     <VStack pl="2">
                       <HStack>
                         <AlertIcon />
                         <AlertTitle>
-                          Caution: Changing Secret May Affect Integrations
+                          Info: Changing Secret May Affect Integrations
                         </AlertTitle>
                       </HStack>
                       <AlertDescription>
@@ -111,7 +111,7 @@ const SecretField = ({
                       <HStack>
                         <AlertIcon />
                         <AlertTitle>
-                          Caution: Update Secret with Care
+                          Warning: Update Secret with Care
                         </AlertTitle>
                       </HStack>
                       <AlertDescription>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -34,10 +34,12 @@ import { generateWebhookSecret } from "api/webhooks";
 import ConfirmationModal from "./ConfirmationModal";
 
 const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
-  const isEditMode = webhook?.id != null;
   console.log(webhook);
   const toast = useToast();
-  const [editSecret, setEditSecret] = useState(false);
+  const isEditMode = webhook?.id != null;
+  const [editSecret, setEditSecret] = useState(
+    !isEditMode || !webhook?.hasSecret
+  );
   const {
     isOpen: isConfirmationOpen,
     onOpen: onConfirmationOpen,
@@ -105,6 +107,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
               isClosable: true,
             });
             onClose();
+            setEditSecret(false);
           }}
         >
           {({ values, handleSubmit, setFieldValue }) => (
@@ -117,7 +120,29 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     header="Header"
                     size="sm"
                   />
-                  {webhook?.hasSecret && !editSecret && (
+
+                  {(!isEditMode || editSecret) && (
+                    <HStack w="100%">
+                      <TextField
+                        name="secret"
+                        placeholder="Secret"
+                        header="Header"
+                        size="sm"
+                      />
+                      <Button
+                        size="sm"
+                        colorScheme="teal"
+                        w="40%"
+                        onClick={() =>
+                          handleGenerateSecret(values, setFieldValue)
+                        }
+                      >
+                        Generate Secret
+                      </Button>
+                    </HStack>
+                  )}
+
+                  {isEditMode && webhook?.hasSecret && !editSecret && (
                     <>
                       <Alert status="warning" mt={4}>
                         <AlertDescription>
@@ -128,42 +153,12 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                       </Alert>
                       <Button
                         onClick={() => {
-                          setFieldValue("secret", ""); // Set the secret value to an empty string
+                          setFieldValue("secret", ""); // Optionally clear the secret value, or keep it if desired
                           setEditSecret(true);
                         }}
                       >
                         Edit Secret
                       </Button>
-                    </>
-                  )}
-
-                  {editSecret && (
-                    <>
-                      <Alert status="info" mt={4}>
-                        <AlertDescription>
-                          Leaving the secret field empty will remove the secret.
-                          If you still want a secret, enter a new value.
-                          Otherwise, cancel editing to keep the old secret.
-                        </AlertDescription>
-                      </Alert>
-                      <HStack w="100%">
-                        <TextField
-                          name="secret"
-                          placeholder="Secret"
-                          header="Header"
-                          size="sm"
-                        />
-                        <Button
-                          size="sm"
-                          colorScheme="teal"
-                          w="40%"
-                          onClick={() =>
-                            handleGenerateSecret(values, setFieldValue)
-                          }
-                        >
-                          Generate Secret
-                        </Button>
-                      </HStack>
                     </>
                   )}
                 </VStack>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useState } from "react";
 import { Formik, Form, Field, FieldArray } from "formik";
 import {
   Modal,
@@ -37,6 +37,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
   const isEditMode = webhook?.id != null;
   console.log(webhook);
   const toast = useToast();
+  const [editSecret, setEditSecret] = useState(false);
   const {
     isOpen: isConfirmationOpen,
     onOpen: onConfirmationOpen,
@@ -112,37 +113,55 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                     header="Header"
                     size="sm"
                   />
-                  {webhook?.hasSecret && (
-                    <Alert status="warning" mt={4}>
-                      <AlertDescription>
-                        If you've lost or forgotten this secret, you can change
-                        it, but be aware that any integrations using this secret
-                        will need to be updated.
-                      </AlertDescription>
-                    </Alert>
+                  {webhook?.hasSecret && !editSecret && (
+                    <>
+                      <Alert status="warning" mt={4}>
+                        <AlertDescription>
+                          If you've lost or forgotten this secret, you can
+                          change it, but be aware that any integrations using
+                          this secret will need to be updated.
+                        </AlertDescription>
+                      </Alert>
+                      <Button
+                        onClick={() => {
+                          setFieldValue("secret", ""); // Set the secret value to an empty string
+                          setEditSecret(true);
+                        }}
+                      >
+                        Edit Secret
+                      </Button>
+                    </>
                   )}
-                  <HStack w="100%">
-                    <TextField
-                      name="secret"
-                      placeholder={
-                        webhook?.hasSecret
-                          ? "Hidden due to security reasons"
-                          : "Secret"
-                      }
-                      header="Header"
-                      size="sm"
-                    />
-                    <Button
-                      size="sm"
-                      colorScheme="teal"
-                      w="40%"
-                      onClick={() =>
-                        handleGenerateSecret(values, setFieldValue)
-                      }
-                    >
-                      {webhook?.hasSecret ? "Change Sceret" : "Generate Secret"}
-                    </Button>
-                  </HStack>
+
+                  {editSecret && (
+                    <>
+                      <Alert status="info" mt={4}>
+                        <AlertDescription>
+                          Leaving the secret field empty will remove the secret.
+                          If you still want a secret, enter a new value.
+                          Otherwise, cancel editing to keep the old secret.
+                        </AlertDescription>
+                      </Alert>
+                      <HStack w="100%">
+                        <TextField
+                          name="secret"
+                          placeholder="Secret"
+                          header="Header"
+                          size="sm"
+                        />
+                        <Button
+                          size="sm"
+                          colorScheme="teal"
+                          w="40%"
+                          onClick={() =>
+                            handleGenerateSecret(values, setFieldValue)
+                          }
+                        >
+                          Generate Secret
+                        </Button>
+                      </HStack>
+                    </>
+                  )}
                 </VStack>
                 <HStack pt="2">
                   <Field type="checkbox" name="verifySsl" />

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -69,13 +69,21 @@ const SecretField = ({
             <>
               {editSecret ? (
                 <>
-                  <Alert status="info" mt={4}>
-                    <AlertDescription>
-                      To retain a secret, please input a new value. An empty
-                      field signifies the removal of the current secret. For
-                      continuity, you may cancel the editing process and retain
-                      the existing secret.
-                    </AlertDescription>
+                  <Alert status="warning" mt={4}>
+                    <VStack pl="2">
+                      <HStack>
+                        <AlertIcon />
+                        <AlertTitle>
+                          Caution: Changing Secret May Affect Integrations
+                        </AlertTitle>
+                      </HStack>
+                      <AlertDescription>
+                        To retain a secret, please input a new value. An empty
+                        field signifies the removal of the current secret. For
+                        continuity, you may cancel the editing process and
+                        retain the existing secret.
+                      </AlertDescription>
+                    </VStack>
                   </Alert>
                   <HStack w="100%">
                     <TextField
@@ -99,17 +107,25 @@ const SecretField = ({
               ) : (
                 <>
                   <Alert status="warning" mt={4}>
-                    <AlertDescription>
-                      If you've lost or forgotten this secret, you can change
-                      it, but be aware that any integrations using this secret
-                      will need to be updated.
-                    </AlertDescription>
+                    <VStack pl="2">
+                      <HStack>
+                        <AlertIcon />
+                        <AlertTitle>
+                          Caution: Update Secret with Care
+                        </AlertTitle>
+                      </HStack>
+                      <AlertDescription>
+                        If you've lost or forgotten this secret, you can change
+                        it, but be aware that any integrations using this secret
+                        will need to be updated.
+                      </AlertDescription>
+                    </VStack>
                   </Alert>
                   <Button
                     onClick={() => setEditSecret(true)}
                     colorScheme="teal"
                   >
-                    Edit Secret
+                    Change Secret
                   </Button>
                 </>
               )}

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -60,8 +60,12 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
     onConfirmationClose();
   };
 
+  const handleCloseModal = () => {
+    setEditSecret(false);
+    onClose();
+  };
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
@@ -270,9 +274,9 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                       </Accordion>
                     )}
                   </FieldArray>
-                )}{" "}
+                )}
                 <ModalFooter>
-                  <Button colorScheme="red" mr={3} onClick={onClose}>
+                  <Button colorScheme="red" mr={3} onClick={handleCloseModal}>
                     Cancel
                   </Button>
                   <Button colorScheme="blue" type="submit">

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
@@ -7,10 +7,11 @@ import { useDisclosure } from "@chakra-ui/react";
 import { createWebhook } from "api/webhooks";
 
 const WebhookMenu = () => {
-  const [editingWebhook, setEditingWebhook] = useState(null);
   const { id: surveyId } = useFetchSurvey();
   const { data, mutate } = useWebhook(surveyId);
   const finalRef = useRef(null);
+
+  const [currentWebhook, setCurrentWebhook] = useState(null);
 
   const {
     isOpen: isFormOpen,
@@ -18,13 +19,8 @@ const WebhookMenu = () => {
     onClose: onFormClose,
   } = useDisclosure();
 
-  const handleAddWebhook = () => {
-    setEditingWebhook(null);
-    onFormOpen();
-  };
-
-  const handleEditWebhook = (webhook) => {
-    setEditingWebhook(webhook);
+  const handleAddOrEditWebhook = (webhook) => {
+    setCurrentWebhook(webhook);
     onFormOpen();
   };
 
@@ -55,18 +51,19 @@ const WebhookMenu = () => {
       <WebhooksModal
         finalRef={finalRef}
         webhooks={data}
-        onAddWebhook={handleAddWebhook}
+        onAddWebhook={handleAddOrEditWebhook}
         onFormOpen={onFormOpen}
+        handleAddOrEditWebhook={handleAddOrEditWebhook}
       />
 
       <WebhookForm
         isOpen={isFormOpen}
         onClose={() => {
           onFormClose();
-          setEditingWebhook(null);
+          setCurrentWebhook(null);
         }}
         onSubmit={handleSubmit}
-        webhook={editingWebhook}
+        webhook={currentWebhook}
       />
     </>
   );

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
@@ -5,6 +5,7 @@ import WebhooksModal from "./WebhookModal";
 import { useWebhook } from "api/webhooks";
 import { useDisclosure } from "@chakra-ui/react";
 import { createWebhook } from "api/webhooks";
+import { updateWebhook } from "api/webhooks";
 
 const WebhookMenu = () => {
   const { id: surveyId } = useFetchSurvey();
@@ -33,15 +34,30 @@ const WebhookMenu = () => {
       secret,
       pageNavigation,
     } = values;
-    await createWebhook(
-      surveyId,
-      url,
-      secret,
-      verifySsl,
-      sourcePages,
-      hasCustomTriggers,
-      pageNavigation
-    );
+
+    if (currentWebhook && currentWebhook.id) {
+      await updateWebhook(
+        currentWebhook.id,
+        surveyId,
+        url,
+        secret,
+        verifySsl,
+        sourcePages,
+        hasCustomTriggers,
+        pageNavigation
+      );
+    } else {
+      await createWebhook(
+        surveyId,
+        url,
+        secret,
+        verifySsl,
+        sourcePages,
+        hasCustomTriggers,
+        pageNavigation
+      );
+    }
+
     mutate();
     onFormClose();
   };

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useFetchSurvey } from "app/contexts/FetchSurvey";
 import WebhookForm from "./WebhookForm";
 import WebhooksModal from "./WebhookModal";
@@ -7,6 +7,7 @@ import { useDisclosure } from "@chakra-ui/react";
 import { createWebhook } from "api/webhooks";
 
 const WebhookMenu = () => {
+  const [editingWebhook, setEditingWebhook] = useState(null);
   const { id: surveyId } = useFetchSurvey();
   const { data, mutate } = useWebhook(surveyId);
   const finalRef = useRef(null);
@@ -18,6 +19,12 @@ const WebhookMenu = () => {
   } = useDisclosure();
 
   const handleAddWebhook = () => {
+    setEditingWebhook(null);
+    onFormOpen();
+  };
+
+  const handleEditWebhook = (webhook) => {
+    setEditingWebhook(webhook);
     onFormOpen();
   };
 
@@ -49,11 +56,17 @@ const WebhookMenu = () => {
         finalRef={finalRef}
         webhooks={data}
         onAddWebhook={handleAddWebhook}
+        onFormOpen={onFormOpen}
       />
+
       <WebhookForm
         isOpen={isFormOpen}
-        onClose={onFormClose}
+        onClose={() => {
+          onFormClose();
+          setEditingWebhook(null);
+        }}
         onSubmit={handleSubmit}
+        webhook={editingWebhook}
       />
     </>
   );

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookMenu.jsx
@@ -67,9 +67,8 @@ const WebhookMenu = () => {
       <WebhooksModal
         finalRef={finalRef}
         webhooks={data}
-        onAddWebhook={handleAddOrEditWebhook}
         onFormOpen={onFormOpen}
-        handleAddOrEditWebhook={handleAddOrEditWebhook}
+        handleWebhookAction={handleAddOrEditWebhook}
       />
 
       <WebhookForm

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
@@ -19,7 +19,7 @@ import {
 import { FaEllipsisV, FaPlus } from "react-icons/fa";
 import WebhookActionCard from "./WebhookActionCard";
 
-const WebhooksModal = ({ finalRef, webhooks, onAddWebhook }) => {
+const WebhooksModal = ({ finalRef, webhooks, onAddWebhook, onFormOpen }) => {
   const {
     isOpen: isWebhooksModalOpen,
     onOpen: openWebhooksModal,
@@ -55,7 +55,10 @@ const WebhooksModal = ({ finalRef, webhooks, onAddWebhook }) => {
             {webhooks &&
               webhooks.map((webhook) => (
                 <Box p={2} key={webhook.id}>
-                  <WebhookActionCard webhook={webhook} />
+                  <WebhookActionCard
+                    webhook={webhook}
+                    onEditWebhook={onFormOpen}
+                  />
                 </Box>
               ))}
           </ModalBody>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
@@ -19,7 +19,13 @@ import {
 import { FaEllipsisV, FaPlus } from "react-icons/fa";
 import WebhookActionCard from "./WebhookActionCard";
 
-const WebhooksModal = ({ finalRef, webhooks, onAddWebhook, onFormOpen }) => {
+const WebhooksModal = ({
+  finalRef,
+  webhooks,
+  onAddWebhook,
+  onFormOpen,
+  handleAddOrEditWebhook,
+}) => {
   const {
     isOpen: isWebhooksModalOpen,
     onOpen: openWebhooksModal,
@@ -57,7 +63,10 @@ const WebhooksModal = ({ finalRef, webhooks, onAddWebhook, onFormOpen }) => {
                 <Box p={2} key={webhook.id}>
                   <WebhookActionCard
                     webhook={webhook}
-                    onEditWebhook={onFormOpen}
+                    onEditWebhook={(specificWebhook) => {
+                      onFormOpen();
+                      handleAddOrEditWebhook(specificWebhook);
+                    }}
                   />
                 </Box>
               ))}

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
@@ -22,9 +22,8 @@ import WebhookActionCard from "./WebhookActionCard";
 const WebhooksModal = ({
   finalRef,
   webhooks,
-  onAddWebhook,
+  handleWebhookAction,
   onFormOpen,
-  handleAddOrEditWebhook,
 }) => {
   const {
     isOpen: isWebhooksModalOpen,
@@ -65,7 +64,7 @@ const WebhooksModal = ({
                     webhook={webhook}
                     onEditWebhook={(specificWebhook) => {
                       onFormOpen();
-                      handleAddOrEditWebhook(specificWebhook);
+                      handleWebhookAction(specificWebhook);
                     }}
                   />
                 </Box>
@@ -77,7 +76,7 @@ const WebhooksModal = ({
               colorScheme="green"
               size="sm"
               leftIcon={<FaPlus />}
-              onClick={onAddWebhook}
+              onClick={handleWebhookAction}
             >
               Create a Webhook
             </Button>


### PR DESCRIPTION
PR Update: Webhook Edit/Update Features

**Key Changes:**

- Streamlined webhook payload construction by introducing a modular functions for API calls.
- Integrated new logic for editing webhooks.
- Secret Management: In edit webhook mode, while keeping the current secret hidden, users can :
            1. Keep the existing secret (by not clicking change secret button).
            2. Generate a new one (after clicking change secret button).
            3. Leave it blank for no secret.
            4. Close or cancel to avoid updating the secret (if they change their mind after clicking change secret button).

The screenshot demonstrate before and after clicking Change Secret
![image](https://github.com/decsys/decsys/assets/90258816/cea19980-1ebb-4072-9327-a81227cc1609)


