### PR TITLE
AB#123544: Bad request during webhook creation

### DIFF
--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -135,15 +135,14 @@ public class WebhookService
 
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         
-         if (webhook.Secret is not null)
-         {
-             using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(webhook.Secret));
-             content.Headers.Add("X-Decsys-Signature",
-                 Encoding.ASCII.GetString(
-                     hmac.ComputeHash(
-                         Encoding.UTF8.GetBytes(json))));
-         }
-         await _client.PostAsync(webhook.CallbackUrl, content);
+        if (webhook.Secret is not null)
+        {
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(webhook.Secret));
+            var signature = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
+            content.Headers.Add("X-Decsys-Signature", Convert.ToBase64String(signature));
+        }
+
+        await _client.PostAsync(webhook.CallbackUrl, content);
     }
     
     public ViewWebhook Edit(string webhookId, WebhookModel model)


### PR DESCRIPTION
This PR resolves the bad request error that would occasionally arise due to a new-line character in the header.

HMAC produces a byte array containing non-ASCII characters. Encoding this byte array using ASCII could result in an invalid string. By encoding the HMAC result with Base64 instead of ASCII, we eliminate this issue and fix the error.