### PR TITLE
AB#123574: Duplicate webhook

### DIFF
--- a/app/Decsys/Services/SurveyService.cs
+++ b/app/Decsys/Services/SurveyService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using Decsys.Config;
 using Decsys.Models;
+using Decsys.Models.Webhooks;
 using Decsys.Repositories.Contracts;
 using Decsys.Services.Contracts;
 
@@ -151,6 +152,20 @@ namespace Decsys.Services
 
             var newId = _surveys.Create(survey, model, ownerId);
 
+            //Duplicated Webhook
+            var originalWebhooks = _webhooks.List(oldId); 
+            foreach (var webhook in originalWebhooks)
+            {
+                var newWebhook = new WebhookModel 
+                {
+                    SurveyId = newId,
+                    CallbackUrl = webhook.CallbackUrl,
+                    VerifySsl = webhook.VerifySsl,
+                    TriggerCriteria = webhook.TriggerCriteria,
+                    Secret = string.Empty, 
+                };
+                _webhooks.Create(newWebhook);
+            }
             if (survey.IsStudy)
             {
                 var study = _surveys.Find(newId);

--- a/app/Decsys/Services/SurveyService.cs
+++ b/app/Decsys/Services/SurveyService.cs
@@ -156,15 +156,7 @@ namespace Decsys.Services
             var originalWebhooks = _webhooks.List(oldId); 
             foreach (var webhook in originalWebhooks)
             {
-                var newWebhook = new WebhookModel 
-                {
-                    SurveyId = newId,
-                    CallbackUrl = webhook.CallbackUrl,
-                    VerifySsl = webhook.VerifySsl,
-                    TriggerCriteria = webhook.TriggerCriteria,
-                    Secret = string.Empty, 
-                };
-                _webhooks.Create(newWebhook);
+                _webhooks.Duplicate(webhook, newId);
             }
             if (survey.IsStudy)
             {
@@ -191,15 +183,7 @@ namespace Decsys.Services
                     var childWebhooks = _webhooks.List(child.Id);
                     foreach (var webhook in childWebhooks)
                     {
-                        var newWebhook = new WebhookModel 
-                        {
-                            SurveyId = newChildId, 
-                            CallbackUrl = webhook.CallbackUrl,
-                            VerifySsl = webhook.VerifySsl,
-                            TriggerCriteria = webhook.TriggerCriteria,
-                            Secret = string.Empty, 
-                        };
-                        _webhooks.Create(newWebhook); 
+                        _webhooks.Duplicate(webhook, newChildId);
                     }
                     
                     await _images.CopyAllSurveyImages(child.Id, newChildId);

--- a/app/Decsys/Services/SurveyService.cs
+++ b/app/Decsys/Services/SurveyService.cs
@@ -186,6 +186,22 @@ namespace Decsys.Services
                             Settings = childSurvey.Settings
                         },
                         ownerId);
+                    
+                    // Duplicating Webhooks for Child Surveys
+                    var childWebhooks = _webhooks.List(child.Id);
+                    foreach (var webhook in childWebhooks)
+                    {
+                        var newWebhook = new WebhookModel 
+                        {
+                            SurveyId = newChildId, 
+                            CallbackUrl = webhook.CallbackUrl,
+                            VerifySsl = webhook.VerifySsl,
+                            TriggerCriteria = webhook.TriggerCriteria,
+                            Secret = string.Empty, 
+                        };
+                        _webhooks.Create(newWebhook); 
+                    }
+                    
                     await _images.CopyAllSurveyImages(child.Id, newChildId);
                 }
             }

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -165,7 +165,8 @@ public class WebhookService
     /// <summary>
     /// Duplicates a webhook by its ID.
     /// </summary>
-    /// <param name="webhookId">The ID of the webhook to duplicate.</param>
+    /// <param name="originalWebhook">The ID of the webhook to duplicate.</param>
+    /// <param name="surveyId">The ID of the survey which is getting duplicated.</param>
     /// <returns>The duplicated Webhook</returns>
     public WebhookModel Duplicate(ViewWebhook originalWebhook, int surveyId)
     {

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -163,7 +163,7 @@ public class WebhookService
     }
 
     /// <summary>
-    /// Duplicates a webhook by its ID.
+    /// Duplicates a webhook
     /// </summary>
     /// <param name="originalWebhook">The ID of the webhook to duplicate.</param>
     /// <param name="surveyId">The ID of the survey which is getting duplicated.</param>

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -162,6 +162,41 @@ public class WebhookService
         return _webhooks.Edit(webhookId, model);
     }
 
+    /// <summary>
+    /// Duplicates a webhook by its ID.
+    /// </summary>
+    /// <param name="webhookId">The ID of the webhook to duplicate.</param>
+    /// <returns>The duplicated Webhook</returns>
+    public ViewWebhook Duplicate(string webhookId)
+    {
+        var existingWebhook = _webhooks.Get(webhookId);
+        if (existingWebhook == null)
+            throw new KeyNotFoundException($"Webhook with ID {webhookId} not found.");
+
+        var duplicateWebhookModel = new WebhookModel
+        {
+            SurveyId = existingWebhook.SurveyId,
+            CallbackUrl = existingWebhook.CallbackUrl,
+            Secret = string.Empty,
+            VerifySsl = existingWebhook.VerifySsl,
+            TriggerCriteria = existingWebhook.TriggerCriteria
+        };
+
+        var duplicateWebhookId = _webhooks.Create(duplicateWebhookModel);
+        var duplicateWebhook = _webhooks.Get(duplicateWebhookId);
+        if (duplicateWebhook == null)
+            throw new InvalidOperationException("Failed to duplicate the webhook.");
+
+        return new ViewWebhook
+        {
+            Id = duplicateWebhook.Id,
+            SurveyId = duplicateWebhook.SurveyId,
+            CallbackUrl = duplicateWebhook.CallbackUrl,
+            HasSecret = false,
+            VerifySsl = duplicateWebhook.VerifySsl,
+            TriggerCriteria = duplicateWebhook.TriggerCriteria
+        };
+    }
 
     /// <summary>
     /// Deletes a webhook by its ID.

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -167,35 +167,20 @@ public class WebhookService
     /// </summary>
     /// <param name="webhookId">The ID of the webhook to duplicate.</param>
     /// <returns>The duplicated Webhook</returns>
-    public ViewWebhook Duplicate(string webhookId)
+    public WebhookModel Duplicate(ViewWebhook originalWebhook, int surveyId)
     {
-        var existingWebhook = _webhooks.Get(webhookId);
-        if (existingWebhook == null)
-            throw new KeyNotFoundException($"Webhook with ID {webhookId} not found.");
-
-        var duplicateWebhookModel = new WebhookModel
+        var newWebhook = new WebhookModel
         {
-            SurveyId = existingWebhook.SurveyId,
-            CallbackUrl = existingWebhook.CallbackUrl,
+            SurveyId = surveyId,
+            CallbackUrl = originalWebhook.CallbackUrl,
+            VerifySsl = originalWebhook.VerifySsl,
+            TriggerCriteria = originalWebhook.TriggerCriteria,
             Secret = string.Empty,
-            VerifySsl = existingWebhook.VerifySsl,
-            TriggerCriteria = existingWebhook.TriggerCriteria
         };
-
-        var duplicateWebhookId = _webhooks.Create(duplicateWebhookModel);
-        var duplicateWebhook = _webhooks.Get(duplicateWebhookId);
-        if (duplicateWebhook == null)
-            throw new InvalidOperationException("Failed to duplicate the webhook.");
-
-        return new ViewWebhook
-        {
-            Id = duplicateWebhook.Id,
-            SurveyId = duplicateWebhook.SurveyId,
-            CallbackUrl = duplicateWebhook.CallbackUrl,
-            HasSecret = false,
-            VerifySsl = duplicateWebhook.VerifySsl,
-            TriggerCriteria = duplicateWebhook.TriggerCriteria
-        };
+        
+        _webhooks.Create(newWebhook);
+        
+        return newWebhook;
     }
 
     /// <summary>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -226,21 +226,10 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
         >
           {({ values, handleSubmit, setFieldValue }) => {
             useEffect(() => {
-              if (
-                webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION === null
-              ) {
-                setPageNavigationChecked(false);
-              } else if (
-                Object.keys(
-                  webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION || {}
-                ).length === 0
-              ) {
-                setPageNavigationChecked(true);
-              } else {
-                setPageNavigationChecked(true);
-              }
+              const isChecked =
+                webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION !== null;
+              setPageNavigationChecked(isChecked);
             }, [webhook]);
-
             return (
               <Form id="myForm" onSubmit={handleSubmit}>
                 <Box p={2}>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -141,6 +141,7 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
   const toast = useToast();
   const isEditMode = webhook?.id != null;
   const [editSecret, setEditSecret] = useState(!isEditMode);
+  const [pageNavigationChecked, setPageNavigationChecked] = useState(true);
 
   useEffect(() => {
     // Reset edit secret mode when modal is opened in edit mode
@@ -223,156 +224,202 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
           initialValues={getInitialValues(webhook)}
           onSubmit={handleFormikSubmit}
         >
-          {({ values, handleSubmit, setFieldValue }) => (
-            <Form id="myForm" onSubmit={handleSubmit}>
-              <Box p={2}>
-                <VStack align="flex-start">
-                  <TextField
-                    name="url"
-                    placeholder="Callback Url"
-                    header="Header"
-                    size="sm"
-                  />
-                  <SecretField
-                    isEditMode={isEditMode}
-                    editSecret={editSecret}
-                    handleGenerateSecret={handleGenerateSecret}
-                    values={values}
-                    setFieldValue={setFieldValue}
-                    setEditSecret={setEditSecret}
-                  />
-                  {!isEditMode && (
-                    <CreateModeSecretField
-                      values={values}
+          {({ values, handleSubmit, setFieldValue }) => {
+            useEffect(() => {
+              if (
+                webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION === null
+              ) {
+                setPageNavigationChecked(false);
+              } else if (
+                Object.keys(
+                  webhook?.triggerCriteria?.eventTypes?.PAGE_NAVIGATION || {}
+                ).length === 0
+              ) {
+                setPageNavigationChecked(true);
+              } else {
+                setPageNavigationChecked(true);
+              }
+            }, [webhook]);
+
+            return (
+              <Form id="myForm" onSubmit={handleSubmit}>
+                <Box p={2}>
+                  <VStack align="flex-start">
+                    <TextField
+                      name="url"
+                      placeholder="Callback Url"
+                      header="Header"
+                      size="sm"
+                    />
+                    <SecretField
+                      isEditMode={isEditMode}
+                      editSecret={editSecret}
                       handleGenerateSecret={handleGenerateSecret}
+                      values={values}
                       setFieldValue={setFieldValue}
+                      setEditSecret={setEditSecret}
                     />
-                  )}
-                </VStack>
-                <HStack pt="2">
-                  <Field type="checkbox" name="verifySsl" />
-                  <Text>Verify SSL</Text>
-                </HStack>
-                {!values.verifySsl && (
-                  <Alert status="warning">
-                    <VStack pl="2">
-                      <HStack>
-                        <AlertIcon />
-                        <AlertTitle>
-                          WARNING: Disabling SSL verification has serious
-                          implications.
-                        </AlertTitle>
-                      </HStack>
-                      <AlertDescription fontSize="sm">
-                        SSL verification helps ensure that hook payloads are
-                        delivered to your URL endpoint securely, keeping your
-                        data away from prying eyes. Disabling this option is not
-                        recommended.
-                      </AlertDescription>
-                    </VStack>
-                  </Alert>
-                )}
-                <VStack align="flex-start">
-                  <LightHeading textAlign="center" size="md" pt="2">
-                    Trigger Criteria
-                  </LightHeading>
-                  <HStack>
-                    <Field type="radio" name="eventTrigger" value="allEvents" />
-                    <Text>All Events</Text>
-                    <Field
-                      type="radio"
-                      name="eventTrigger"
-                      value="customEvents"
-                    />
-                    <Text>Customize Events</Text>
-                  </HStack>
-                </VStack>
-                {values.eventTrigger === "customEvents" && (
-                  <FieldArray name="sourcePages">
-                    {({ push, remove }) => (
-                      <Accordion
-                        borderWidth={1}
-                        borderRadius={5}
-                        defaultIndex={[0]}
-                        allowToggle
-                        pl="2"
-                      >
-                        <AccordionItem>
-                          <AccordionButton width="100%">
-                            <Box textAlign="left">
-                              <HStack>
-                                <Field type="checkbox" name="pageNavigation" />
-                                <Text>Page Navigation</Text>
-                              </HStack>
-                            </Box>
-                            <AccordionIcon />
-                          </AccordionButton>
-                          <AccordionPanel pb={4}>
-                            <VStack w="100%" align="flex-start">
-                              <Text fontSize="sm">
-                                Please specify the page numbers of the survey,
-                                on which an event should trigger the webhook
-                              </Text>
-                              <Box w="100%" borderWidth={1} borderRadius={5}>
-                                <HStack w="100%" p="2" justify="space-between">
-                                  <LightHeading
-                                    textAlign="center"
-                                    as="h4"
-                                    size="md"
-                                  >
-                                    Trigger Filters
-                                  </LightHeading>
-                                  <IconButton
-                                    colorScheme="green"
-                                    icon={<FaPlusCircle />}
-                                    onClick={() => push("")}
-                                  />
-                                </HStack>
-                                {values.sourcePages.map((sourcePage, index) => (
-                                  <Flex key={index} w="100%">
-                                    <HStack w="100%" p="2">
-                                      <Flex w="40%">
-                                        <FormikInput
-                                          name={`sourcePages.${index}`}
-                                          placeholder="Source page (number)"
-                                          type="number"
-                                          size="sm"
-                                          collapseError
-                                        />
-                                      </Flex>
-                                      <IconButton
-                                        colorScheme="red"
-                                        size="sm"
-                                        icon={<FaTimes />}
-                                        onClick={() => remove(index)}
-                                      />
-                                    </HStack>
-                                  </Flex>
-                                ))}
-                              </Box>
-                            </VStack>
-                          </AccordionPanel>
-                        </AccordionItem>
-                      </Accordion>
+                    {!isEditMode && (
+                      <CreateModeSecretField
+                        values={values}
+                        handleGenerateSecret={handleGenerateSecret}
+                        setFieldValue={setFieldValue}
+                      />
                     )}
-                  </FieldArray>
-                )}
-                <ModalFooter>
-                  <Button colorScheme="red" mr={3} onClick={handleCloseModal}>
-                    Cancel
-                  </Button>
-                  <Button colorScheme="blue" type="submit">
-                    Save
-                  </Button>
-                </ModalFooter>
-              </Box>
-              <ConfirmationModal
-                isOpen={isConfirmationOpen}
-                onClose={onConfirmationClose}
-                onConfirm={() => handleConfirmNewSecret(setFieldValue)}
-              />
-            </Form>
-          )}
+                  </VStack>
+                  <HStack pt="2">
+                    <Field type="checkbox" name="verifySsl" />
+                    <Text>Verify SSL</Text>
+                  </HStack>
+                  {!values.verifySsl && (
+                    <Alert status="warning">
+                      <VStack pl="2">
+                        <HStack>
+                          <AlertIcon />
+                          <AlertTitle>
+                            WARNING: Disabling SSL verification has serious
+                            implications.
+                          </AlertTitle>
+                        </HStack>
+                        <AlertDescription fontSize="sm">
+                          SSL verification helps ensure that hook payloads are
+                          delivered to your URL endpoint securely, keeping your
+                          data away from prying eyes. Disabling this option is
+                          not recommended.
+                        </AlertDescription>
+                      </VStack>
+                    </Alert>
+                  )}
+                  <VStack align="flex-start">
+                    <LightHeading textAlign="center" size="md" pt="2">
+                      Trigger Criteria
+                    </LightHeading>
+                    <HStack>
+                      <Field
+                        type="radio"
+                        name="eventTrigger"
+                        value="allEvents"
+                      />
+                      <Text>All Events</Text>
+                      <Field
+                        type="radio"
+                        name="eventTrigger"
+                        value="customEvents"
+                      />
+                      <Text>Customize Events</Text>
+                    </HStack>
+                  </VStack>
+                  {values.eventTrigger === "customEvents" && (
+                    <FieldArray name="sourcePages">
+                      {({ push, remove }) => (
+                        <Accordion
+                          borderWidth={1}
+                          borderRadius={5}
+                          defaultIndex={[0]}
+                          allowToggle
+                          pl="2"
+                        >
+                          <AccordionItem>
+                            <AccordionButton width="100%">
+                              <Box textAlign="left">
+                                <HStack>
+                                  <Field
+                                    type="checkbox"
+                                    name="pageNavigation"
+                                    checked={pageNavigationChecked}
+                                    onChange={(e) => {
+                                      setFieldValue(
+                                        "pageNavigation",
+                                        e.target.checked
+                                      );
+                                      setPageNavigationChecked(
+                                        e.target.checked
+                                      );
+                                    }}
+                                  />
+                                  <Text>Page Navigation</Text>
+                                </HStack>
+                              </Box>
+                              <AccordionIcon />
+                            </AccordionButton>
+                            <AccordionPanel pb={4}>
+                              <VStack w="100%" align="flex-start">
+                                <Alert status="info">
+                                  <AlertIcon />
+                                  <AlertDescription fontSize="sm">
+                                    Ensure "Page Navigation" is ticked to use
+                                    triggers on navigation filters. If Trigger
+                                    Filters are empty with this option enabled,
+                                    the webhook will be triggered by all pages.
+                                  </AlertDescription>
+                                </Alert>
+                                <Box w="100%" borderWidth={1} borderRadius={5}>
+                                  <HStack
+                                    w="100%"
+                                    p="2"
+                                    justify="space-between"
+                                  >
+                                    <LightHeading
+                                      textAlign="center"
+                                      as="h4"
+                                      size="md"
+                                    >
+                                      Trigger Filters
+                                    </LightHeading>
+                                    <IconButton
+                                      colorScheme="green"
+                                      icon={<FaPlusCircle />}
+                                      onClick={() => push("")}
+                                    />
+                                  </HStack>
+                                  {values.sourcePages.map(
+                                    (sourcePage, index) => (
+                                      <Flex key={index} w="100%">
+                                        <HStack w="100%" p="2">
+                                          <Flex w="40%">
+                                            <FormikInput
+                                              name={`sourcePages.${index}`}
+                                              placeholder="Source page (number)"
+                                              type="number"
+                                              size="sm"
+                                              collapseError
+                                            />
+                                          </Flex>
+                                          <IconButton
+                                            colorScheme="red"
+                                            size="sm"
+                                            icon={<FaTimes />}
+                                            onClick={() => remove(index)}
+                                          />
+                                        </HStack>
+                                      </Flex>
+                                    )
+                                  )}
+                                </Box>
+                              </VStack>
+                            </AccordionPanel>
+                          </AccordionItem>
+                        </Accordion>
+                      )}
+                    </FieldArray>
+                  )}
+                  <ModalFooter>
+                    <Button colorScheme="red" mr={3} onClick={handleCloseModal}>
+                      Cancel
+                    </Button>
+                    <Button colorScheme="blue" type="submit">
+                      Save
+                    </Button>
+                  </ModalFooter>
+                </Box>
+                <ConfirmationModal
+                  isOpen={isConfirmationOpen}
+                  onClose={onConfirmationClose}
+                  onConfirm={() => handleConfirmNewSecret(setFieldValue)}
+                />
+              </Form>
+            );
+          }}
         </Formik>
       </ModalContent>
     </Modal>

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookForm.jsx
@@ -77,7 +77,7 @@ const SecretField = ({
                           Info: Changing Secret May Affect Integrations
                         </AlertTitle>
                       </HStack>
-                      <AlertDescription>
+                      <AlertDescription fontSize="sm">
                         To change the secret, please input a new value. An empty
                         field signifies the removal of the current secret. For
                         continuity, you may cancel the editing process and
@@ -114,7 +114,7 @@ const SecretField = ({
                           Warning: Update Secret with Care
                         </AlertTitle>
                       </HStack>
-                      <AlertDescription>
+                      <AlertDescription fontSize="sm">
                         If you've lost or forgotten this secret, you can change
                         it, but be aware that any integrations using this secret
                         will need to be updated.
@@ -345,13 +345,20 @@ const WebhookForm = ({ isOpen, onClose, onSubmit, webhook }) => {
                             <AccordionPanel pb={4}>
                               <VStack w="100%" align="flex-start">
                                 <Alert status="info">
-                                  <AlertIcon />
-                                  <AlertDescription fontSize="sm">
-                                    Ensure "Page Navigation" is ticked to use
-                                    triggers on navigation filters. If Trigger
-                                    Filters are empty with this option enabled,
-                                    the webhook will be triggered by all pages.
-                                  </AlertDescription>
+                                  <VStack>
+                                    <HStack>
+                                      <AlertIcon />
+                                      <AlertTitle>
+                                        Ensure Page Navigation is checked to use
+                                        triggers on navigation filters.
+                                      </AlertTitle>
+                                    </HStack>
+                                    <AlertDescription fontSize="sm">
+                                      If Trigger Filters are left empty with
+                                      this option enabled, the webhook will be
+                                      triggered by all pages.
+                                    </AlertDescription>
+                                  </VStack>
                                 </Alert>
                                 <Box w="100%" borderWidth={1} borderRadius={5}>
                                   <HStack


### PR DESCRIPTION
### Description
This PR ensure webhook gets duplicated when Survey or Studies are duplicated
It also fixes page navigation for webhooks being checked (or not) when survey gets duplicated


### Notes:
If _PAGE_NAVIGATION_ is **null**, then pageNavigationChecked is set to **false**.
If _PAGE_NAVIGATION_ is an **empty object** (its keys length is 0), then pageNavigationChecked is set to **true**.
If _PAGE_NAVIGATION_ is an **object with data** (anything other than null or an empty object), then pageNavigationChecked is set to **true**.