### PR TITLE
AB#119590: Webhook Payload Changes

### DIFF
--- a/app/Decsys/Controllers/ParticipantProgressController.cs
+++ b/app/Decsys/Controllers/ParticipantProgressController.cs
@@ -395,7 +395,7 @@ namespace Decsys.Controllers
             }
             
             // Trigger webhook
-            var payload = _events.PageResponseSummary(instanceId, participantId, currentPageId);
+            var payload = _events.ResultsSummary(instanceId, participantId);
             string surveyFriendlyId = FriendlyIds.Encode(surveyId, instanceId);
             
             var eventType = new PageNavigation


### PR DESCRIPTION
### Description
Switch PageNavigation Webhook Payload to be ParticipantResultsSummary

### Notes
The payload's type has changed from _PageResponseSummary_ to _ParticipantResultsSummary_ as we've transitioned to using the _ResultsSummary_ method. This shift means that, rather than the webhook receiving individual pages for the payload, it now aggregates pages responses from each consecutive page.