### PR TITLE
AB#130743: Popper warning fix

### DIFF
--- a/app/client-app/src/app/pages/Editor/components/PageList/Header.jsx
+++ b/app/client-app/src/app/pages/Editor/components/PageList/Header.jsx
@@ -2,7 +2,7 @@ import { Button, Flex, HStack } from "@chakra-ui/react";
 import LightHeading from "components/core/LightHeading";
 import { FaPlus } from "react-icons/fa";
 import { usePageListContext } from "../../contexts/PageList";
-import WebhookMenu from "../Webhook/WebhookMenu";
+import WebhookManager from "../Webhook/WebhookManager";
 import { useServerConfig } from "api/config";
 
 const Header = () => {
@@ -16,7 +16,7 @@ const Header = () => {
         <Button colorScheme="green" onClick={addPage} leftIcon={<FaPlus />}>
           Add Page
         </Button>
-        {webhookEnabled && <WebhookMenu />}
+        {webhookEnabled && <WebhookManager />}
       </HStack>
     </Flex>
   );

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookManager.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookManager.jsx
@@ -7,7 +7,7 @@ import { useDisclosure } from "@chakra-ui/react";
 import { createWebhook } from "api/webhooks";
 import { updateWebhook } from "api/webhooks";
 
-const WebhookMenu = () => {
+const WebhookManager = () => {
   const { id: surveyId } = useFetchSurvey();
   const { data, mutate } = useWebhook(surveyId);
   const finalRef = useRef(null);
@@ -84,4 +84,4 @@ const WebhookMenu = () => {
   );
 };
 
-export default WebhookMenu;
+export default WebhookManager;

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
@@ -31,8 +31,8 @@ const WebhooksModal = ({
     onClose: closeWebhooksModal,
   } = useDisclosure();
 
-  return (
-    <>
+  const WebhookMenu = () => (
+    <Box>
       <Menu>
         <MenuButton
           border="thin solid"
@@ -45,6 +45,11 @@ const WebhooksModal = ({
           <MenuItem onClick={openWebhooksModal}>Manage Webhooks ...</MenuItem>
         </MenuList>
       </Menu>
+    </Box>
+  );
+  return (
+    <>
+      <WebhookMenu />
 
       <Modal
         finalFocusRef={finalRef}

--- a/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
+++ b/app/client-app/src/app/pages/Editor/components/Webhook/WebhookModal.jsx
@@ -32,25 +32,22 @@ const WebhooksModal = ({
   } = useDisclosure();
 
   const WebhookMenu = () => (
-    <Box>
-      <Menu>
-        <MenuButton
-          border="thin solid"
-          borderColor="gray.500"
-          as={IconButton}
-          icon={<FaEllipsisV />}
-          boxSize={"40px"}
-        />
-        <MenuList>
-          <MenuItem onClick={openWebhooksModal}>Manage Webhooks ...</MenuItem>
-        </MenuList>
-      </Menu>
-    </Box>
+    <Menu>
+      <MenuButton
+        border="thin solid"
+        borderColor="gray.500"
+        as={IconButton}
+        icon={<FaEllipsisV />}
+        boxSize={"40px"}
+      />
+      <MenuList>
+        <MenuItem onClick={openWebhooksModal}>Manage Webhooks ...</MenuItem>
+      </MenuList>
+    </Menu>
   );
   return (
-    <>
+    <Box>
       <WebhookMenu />
-
       <Modal
         finalFocusRef={finalRef}
         isOpen={isWebhooksModalOpen}
@@ -93,7 +90,7 @@ const WebhooksModal = ({
           </ModalFooter>
         </ModalContent>
       </Modal>
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Fix "Popper: CSS "margin"  styles cannot be used to apply padding" warning by adding a chakra div to the menu component

Renamed WebhookMenu to WebhookManager, and refactored menu component to a WebhookMenu component