### PR TITLE
AB#131442: Webhook PreviewTrigger Endpoint

### DIFF
--- a/app/Decsys/Controllers/WebhooksController.cs
+++ b/app/Decsys/Controllers/WebhooksController.cs
@@ -108,4 +108,17 @@ public class WebhooksController : ControllerBase
         return NoContent();
     }
     
+    [HttpPost("preview")]
+    [SwaggerOperation("Preview if a webhook would trigger")]
+    [SwaggerResponse(200, "Webhook would be triggered")]
+    [SwaggerResponse(204, "Webhook would not be triggered")]
+    [SwaggerResponse(400, "Invalid request payload")]
+    public async Task<IActionResult> PreviewTrigger([FromBody] PayloadModel payload)
+    {
+        var result = await _webhooks.PreviewTrigger(payload);
+        if(result != null)
+            return Ok(result);
+        
+        return NoContent();
+    }
 }

--- a/app/Decsys/Controllers/WebhooksController.cs
+++ b/app/Decsys/Controllers/WebhooksController.cs
@@ -113,9 +113,9 @@ public class WebhooksController : ControllerBase
     [SwaggerResponse(200, "Webhook would be triggered")]
     [SwaggerResponse(204, "Webhook would not be triggered")]
     [SwaggerResponse(400, "Invalid request payload")]
-    public async Task<IActionResult> PreviewTrigger([FromBody] PayloadModel payload)
+    public IActionResult PreviewTrigger([FromBody] PayloadModel payload)
     {
-        var result = await _webhooks.PreviewTrigger(payload);
+        var result =  _webhooks.PreviewTrigger(payload);
         if(result != null)
             return Ok(result);
         

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -193,12 +193,7 @@ public class WebhookService
         _webhooks.Delete(webhookId);
     }
     
-    /// <summary>
-    /// Checks if a webhook would be triggered based on the provided payload.
-    /// </summary>
-    /// <param name="payload">The payload to check.</param>
-    /// <returns>The payload if a webhook would be triggered; null otherwise.</returns>
-    public Task<PayloadModel?> PreviewTrigger(PayloadModel payload)
+    public PayloadModel? PreviewTrigger(PayloadModel payload)
     {
         var (surveyId, instanceId) = FriendlyIds.Decode(payload.SurveyId);
         var webhooks = _webhooks.List(surveyId);

--- a/app/Decsys/Services/WebhookService.cs
+++ b/app/Decsys/Services/WebhookService.cs
@@ -192,4 +192,25 @@ public class WebhookService
     {
         _webhooks.Delete(webhookId);
     }
+    
+    /// <summary>
+    /// Checks if a webhook would be triggered based on the provided payload.
+    /// </summary>
+    /// <param name="payload">The payload to check.</param>
+    /// <returns>The payload if a webhook would be triggered; null otherwise.</returns>
+    public Task<PayloadModel?> PreviewTrigger(PayloadModel payload)
+    {
+        var (surveyId, instanceId) = FriendlyIds.Decode(payload.SurveyId);
+        var webhooks = _webhooks.List(surveyId);
+
+        foreach (var webhook in webhooks)
+        {
+            if (FilterCriteria(webhook, payload))
+            {
+                return payload;
+            }
+        }
+        return null;
+    }
+
 }

--- a/app/client-app/src/app/pages/Results.jsx
+++ b/app/client-app/src/app/pages/Results.jsx
@@ -32,6 +32,7 @@ import {
   Grid,
   useTheme,
   Icon,
+  Box,
 } from "@chakra-ui/react";
 import { Page, EmptyState, BusyPage } from "components/core";
 import { navigate } from "@reach/router";
@@ -137,27 +138,29 @@ const ExportResultsMenu = ({ surveyId, instanceId, results }) => {
   };
 
   return (
-    <Menu>
-      <MenuButton
-        as={Button}
-        borderColor="gray.400"
-        borderWidth={1}
-        rightIcon={<FaChevronDown />}
-      >
-        {isExporting ? <BusyPage verb="Exporting" /> : "Export to file"}
-      </MenuButton>
-      <MenuList>
-        <MenuItem onClick={handleExportCsvClick}>
-          Response Summary (CSV)
-        </MenuItem>
-        <MenuItem onClick={handleExportSummaryClick}>
-          Response Summary (JSON)
-        </MenuItem>
-        <MenuItem onClick={handleExportFullClick}>
-          Full Event Log (JSON)
-        </MenuItem>
-      </MenuList>
-    </Menu>
+    <Box>
+      <Menu>
+        <MenuButton
+          as={Button}
+          borderColor="gray.400"
+          borderWidth={1}
+          rightIcon={<FaChevronDown />}
+        >
+          {isExporting ? <BusyPage verb="Exporting" /> : "Export to file"}
+        </MenuButton>
+        <MenuList>
+          <MenuItem onClick={handleExportCsvClick}>
+            Response Summary (CSV)
+          </MenuItem>
+          <MenuItem onClick={handleExportSummaryClick}>
+            Response Summary (JSON)
+          </MenuItem>
+          <MenuItem onClick={handleExportFullClick}>
+            Full Event Log (JSON)
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </Box>
   );
 };
 


### PR DESCRIPTION
### Description
This PR adds a `PreviewTrigger` method in the service and `preview` endpoint.
This PR also fixes another popper warning by the use of chakra DIV


### Notes
- Decodes the SurveyId from the provided payload.
- Lists all webhooks associated with the decoded survey ID.
- For each webhook, if the event in the payload meets its specified trigger criteria, the method returns the payload, indicating that it would be dispatched to a webhook's callback URL. If no webhook's criteria is met, it returns null.
- Endpoint which indicates if the webhook would be triggered
- Box is the most abstract component on top of which all other Chakra UI components are built. By default, it renders a `div` element
