### PR TITLE
AB#131849: LogEvent for Webhook Preview

### DIFF
--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -127,8 +127,6 @@ const Preview = ({ id, location }) => {
     }
   };
 
-  console.log(participantSummary);
-
   const handleClick = async () => {
     // you'd think busy state in preview wouldn't be worth it
 

--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -12,6 +12,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { pickRandomItem } from "services/randomizer";
+import { getPageResponseItem } from "services/page-items";
 
 const navigateBack = (location) =>
   navigate(location?.state?.backRedirect ?? `/admin/`);
@@ -58,13 +59,59 @@ const Preview = ({ id, location }) => {
   const [lastPage, setLastPage] = useState(false);
   useEffect(() => setLastPage(page === pages.length - 1), [page, pages.length]);
   const confirmRedirectModal = useDisclosure();
+
   const [participantSummary, setParticipantSummary] = useState({
     id: "PreviewParticipant",
     surveyStarted: new Date(),
     responses: [],
   });
 
-  const logEvent = (source, type, paylod) => {};
+  const logEvent = (source, type, payload) => {
+    //Debuging, TODO: Remove
+    console.log("Event Source:", source);
+    console.log("Event Type:", type);
+    console.log("Event Payload:", payload);
+
+    if (type === "PAGE_LOAD") {
+      const pageResponseItem = getPageResponseItem(pages[page].components);
+
+      // Check if a response item exists for the current page
+      if (pageResponseItem) {
+        // Find the item marked as IsQuestionItem
+        let questionItem = pages[page].components.find((x) => x.isQuestionItem);
+
+        // If not found, find the first built-in content item
+        if (!questionItem) {
+          questionItem = pages[page].components.find((x) => isBuiltIn(x.type));
+        }
+
+        // If there's an item, try to get content from it, else return null
+        let questionContent = null;
+        if (questionItem) {
+          questionContent = "TODO";
+        }
+
+        setParticipantSummary((prevState) => ({
+          ...prevState,
+          responses: [
+            ...prevState.responses,
+            {
+              page: "TODO",
+              question: "TODO",
+              responseType: "TODO",
+              pageLoad: new Date(),
+              order: "TODO",
+              isOptional: "TODO",
+            },
+          ],
+        }));
+      }
+    } else if (type == "COMPONENT_RESULTS") {
+      {
+        //TODO
+      }
+    }
+  };
 
   const handleClick = async () => {
     // you'd think busy state in preview wouldn't be worth it

--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -69,6 +69,7 @@ const Preview = ({ id, location }) => {
 
   const logEvent = (source, type, payload) => {
     const pageResponseItem = getPageResponseItem(pages[page].components);
+
     if (type === "decsys.platform.PAGE_LOAD") {
       // Check if a response item exists for the current page
       if (pageResponseItem) {
@@ -96,7 +97,7 @@ const Preview = ({ id, location }) => {
               page: pages[page].order,
               pageName: pages[page].name,
               question: questionContent,
-              responseType: type,
+              responseType: pageResponseItem.type,
               order: pages[page].order,
               pageLoad: new Date(),
               isOptional: pageResponseItem.isOptional,
@@ -125,6 +126,8 @@ const Preview = ({ id, location }) => {
       }
     }
   };
+
+  console.log(participantSummary);
 
   const handleClick = async () => {
     // you'd think busy state in preview wouldn't be worth it

--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -58,6 +58,11 @@ const Preview = ({ id, location }) => {
   const [lastPage, setLastPage] = useState(false);
   useEffect(() => setLastPage(page === pages.length - 1), [page, pages.length]);
   const confirmRedirectModal = useDisclosure();
+  const [participantSummary, setParticipantSummary] = useState({
+    id: "PreviewParticipant",
+    surveyStarted: new Date(),
+    responses: [],
+  });
 
   const handleClick = async () => {
     // you'd think busy state in preview wouldn't be worth it

--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -64,6 +64,8 @@ const Preview = ({ id, location }) => {
     responses: [],
   });
 
+  const logEvent = (source, type, paylod) => {};
+
   const handleClick = async () => {
     // you'd think busy state in preview wouldn't be worth it
 
@@ -91,6 +93,7 @@ const Preview = ({ id, location }) => {
         lastPage={lastPage}
         handleNextClick={handleClick}
         isBusy={isBusy}
+        logEvent={logEvent}
       />
       <ConfirmRedirectModal
         modalState={confirmRedirectModal}

--- a/app/client-app/src/app/pages/Preview.jsx
+++ b/app/client-app/src/app/pages/Preview.jsx
@@ -69,27 +69,23 @@ const Preview = ({ id, location }) => {
 
   const logEvent = (source, type, payload) => {
     const pageResponseItem = getPageResponseItem(pages[page].components);
-    const relavantPage = pages.find((p) =>
-      p.components.some((c) => c.id === source)
-    );
-    const pageIndex = relavantPage?.order - 1;
-
     if (type === "decsys.platform.PAGE_LOAD") {
       // Check if a response item exists for the current page
       if (pageResponseItem) {
         // Find the item marked as IsQuestionItem
         let questionItem = pages[page].components.find((x) => x.isQuestionItem);
-
-        // If there's an item, try to get content from it, else return null
         let questionContent = null;
+
+        // If there's a question item, try to get content from it
         if (questionItem) {
           questionContent = questionItem.params.text;
         }
-
-        // If not found, find the first built-in content item
-        if (!questionItem) {
+        // If no question item was found, then check for a built-in content item
+        else {
           questionItem = pages[page].components.find((x) => isBuiltIn(x.type));
-          questionContent = questionItem.params.text;
+          if (questionItem) {
+            questionContent = questionItem.params.text;
+          }
         }
 
         setParticipantSummary((prevState) => ({
@@ -97,11 +93,11 @@ const Preview = ({ id, location }) => {
           responses: [
             ...prevState.responses,
             {
-              page: relavantPage?.order,
+              page: pages[page].order,
               pageName: pages[page].name,
               question: questionContent,
               responseType: type,
-              order: relavantPage?.order,
+              order: pages[page].order,
               pageLoad: new Date(),
               isOptional: pageResponseItem.isOptional,
             },
@@ -109,6 +105,10 @@ const Preview = ({ id, location }) => {
         }));
       }
     } else if (type == "decsys.platform.COMPONENT_RESULTS") {
+      const relavantPage = pages.find((p) =>
+        p.components.some((c) => c.id === source)
+      );
+      const pageIndex = relavantPage?.order - 1;
       if (pageIndex > -1) {
         setParticipantSummary((prevState) => {
           let updatedResponses = [...prevState.responses];


### PR DESCRIPTION
### Desciption
This PR captures details required for webhook in preview mode

## Notes
- Initialize a _participantSummary_ state
- _logEvent_ Function which handles different event types during the survey preview.
- For _PAGE_LOAD_ Events:
  - Checks if the current page has a response item.
  - Determines the content of the question on the page.
  - Updates participantSummary with details like page order, name, question content, event type, load time, and if the response is optional or not
- For _COMPONENT_RESULTS_ Events:
  - Finds the page containing the component that generated the result.
  - Updates the corresponding response in participantSummary with the participant's payload and recording time.
