### PR TITLE
AB#161353: added cli command webhooks list

### DIFF
--- a/app/Decsys/Commands/GenerateId.cs
+++ b/app/Decsys/Commands/GenerateId.cs
@@ -8,19 +8,21 @@ public class GenerateId : Command
     public GenerateId(string name)
         : base(name, "Generates a secure unique identifier in Base64Url format, suitable for use as a secret.")
     {
-        var optHash = new Option<bool>(new[] { "-s", "--sha", "--hash" },
+        var optHash = new Option<bool>(["-s", "--sha", "--hash"],
             "Also output a SHA256 hash of the ID in Base64Url format.");
         Add(optHash);
 
         this.SetHandler(
             (logger, console, hash) =>
             {
-                this.ConfigureServices(s =>
-                        ServiceCollectionServiceExtensions.AddSingleton<IConsole>(s, _ => logger).AddSingleton<ILoggerFactory>(_ => console).AddTransient<Runners.GenerateId>())
+                this.ConfigureServices(s => s
+                        .AddSingleton<ILoggerFactory>(_ => logger)
+                        .AddSingleton<IConsole>(_ => console)
+                        .AddTransient<Runners.GenerateId>())
                     .GetRequiredService<Runners.GenerateId>().Run(hash);
             },
-            Bind.FromServiceProvider<IConsole>(),
             Bind.FromServiceProvider<ILoggerFactory>(),
+            Bind.FromServiceProvider<IConsole>(),
             optHash);
     }
 }

--- a/app/Decsys/Commands/Hash.cs
+++ b/app/Decsys/Commands/Hash.cs
@@ -13,10 +13,10 @@ public class Hash : Command
         this.SetHandler((logger, console, input) =>
             {
                 this
-                    .ConfigureServices((s) =>
-                        ServiceCollectionServiceExtensions.AddSingleton<ILoggerFactory>(s, _ => logger)
-                            .AddSingleton<IConsole>(_ => console)
-                            .AddTransient<Runners.Hash>()
+                    .ConfigureServices((s) => s
+                        .AddSingleton<ILoggerFactory>(_ => logger)
+                        .AddSingleton<IConsole>(_ => console)
+                        .AddTransient<Runners.Hash>()
                     )
                     .GetRequiredService<Runners.Hash>()
                     .Run(input);
@@ -25,5 +25,4 @@ public class Hash : Command
             Bind.FromServiceProvider<IConsole>(),
             argInput);
     }
-    
 }

--- a/app/Decsys/Commands/ListWebhooks.cs
+++ b/app/Decsys/Commands/ListWebhooks.cs
@@ -1,0 +1,47 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using Decsys.Commands.Helpers;
+using Decsys.Config;
+using MongoDB.Driver;
+
+namespace Decsys.Commands;
+
+public class ListWebhooks : Command
+{
+    public ListWebhooks(string name)
+        : base(name, "List all Webhooks configured for a given Survey.")
+    {
+        var optConnectionString = new Option<string?>(["--connection-string", "-c"],
+            "Database Connection String if not specified in Configuration");
+        Add(optConnectionString);
+
+        var argSurveyId = new Argument<string>("survey-id",
+            "The target Survey Id, either as a numeric Survey Id or a combined Friendly Id for Survey and Instance");
+        Add(argSurveyId);
+
+        this.SetHandler((
+                logger, console, config,
+                surveyId,
+                overrideConnectionString) =>
+            {
+                var mongoClient = new MongoClient(overrideConnectionString ?? config.GetConnectionString("mongo"));
+                
+                console.Out.WriteLine(config.GetConnectionString("mongo"));
+
+                this.ConfigureServices(s => s
+                        .AddSingleton<ILoggerFactory>(_ => logger)
+                        .AddSingleton<IConsole>(_ => console)
+                        .AddSingleton<IConfiguration>(_ => config)
+                        .AddMongoDb(mongoClient)
+                        .AddMongoDbRepositories()
+                        .Configure<HostedDbSettings>(config.GetSection("Hosted"))
+                        .AddTransient<Runners.ListWebhooks>())
+                    .GetRequiredService<Runners.ListWebhooks>().Run(surveyId);
+            },
+            Bind.FromServiceProvider<ILoggerFactory>(),
+            Bind.FromServiceProvider<IConsole>(),
+            Bind.FromServiceProvider<IConfiguration>(),
+            argSurveyId,
+            optConnectionString);
+    }
+}

--- a/app/Decsys/Commands/Runners/ListWebhooks.cs
+++ b/app/Decsys/Commands/Runners/ListWebhooks.cs
@@ -1,0 +1,76 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Text.Json;
+using IdentityModel;
+using IdentityServer4.Models;
+using ConsoleTableExt;
+using Decsys.Repositories.Contracts;
+using Decsys.Utilities;
+
+namespace Decsys.Commands.Runners;
+
+public class ListWebhooks
+{
+    private readonly IConsole _console;
+    private readonly IWebhookRepository _webhooks;
+    private readonly ILogger<Hash> _logger;
+
+    public ListWebhooks(
+        ILoggerFactory logger, IConsole console, IWebhookRepository webhooks)
+    {
+        _console = console;
+        _webhooks = webhooks;
+        _logger = logger.CreateLogger<Hash>();
+    }
+
+    public void Run(string inputId)
+    {
+        if (!int.TryParse(inputId, out var surveyId))
+        {
+            // they didn't pass an integer input; decode it from a friendly Id instead
+            (surveyId, _) = FriendlyIds.Decode(inputId);
+        }
+
+        _console.Out.WriteLine(
+            $"Webhooks configured for Survey: {surveyId}{(inputId != surveyId.ToString() ? $" ({inputId})" : "")}");
+
+        var hooks = _webhooks.List(surveyId);
+
+        if (hooks.Count != 0)
+        {
+            foreach (var hook in hooks)
+            {
+                var outputRows = new List<List<object>>
+                {
+                    new() { "Id", hook.Id },
+                    new() { "Callback URL", hook.CallbackUrl },
+                    new()
+                    {
+                        // TODO this table will need improving when other filter types are added
+                        "PAGE_NAVIGATION Trigger Filters",
+                        JsonSerializer.Serialize(hook.TriggerCriteria.EventTypes.PageNavigation)
+                    },
+                };
+
+                _console.Out.Write(ConsoleTableBuilder
+                    .From(outputRows)
+                    .WithCharMapDefinition(CharMapDefinition.FramePipDefinition)
+                    .Export()
+                    .ToString());
+            }
+        }
+        else
+        {
+            var outputRows = new List<string>
+            {
+                "\u26a0\ufe0f No webhooks configured!"
+            };
+
+            _console.Out.Write(ConsoleTableBuilder
+                .From(outputRows)
+                .WithCharMapDefinition(CharMapDefinition.FramePipDefinition)
+                .Export()
+                .ToString());
+        }
+    }
+}

--- a/app/Decsys/Startup/Cli/CliEntrypoint.cs
+++ b/app/Decsys/Startup/Cli/CliEntrypoint.cs
@@ -16,6 +16,11 @@ public class CliEntrypoint : RootCommand
             new GenerateId("generate-id"),
             new Hash("hash")
         });
+        
+        AddCommand(new Command("webhooks", "Actions for working with Survey webhooks")
+        {
+            new ListWebhooks("list")
+        });
     }
     
 }


### PR DESCRIPTION
<!--
⚠ Ensure the PR title starts with a reference to the primary work item it completes, in the form `AB#<id>: My PR Title`.
-->

## Overview

This PR adds a new cli command `webhooks list`.

It allows listing the webhooks configured for a given Survey, by raw Survey Id, or a friendly Combined Id (survey + instance):

- `decsys webhooks list 89` -> list webhooks configured for Survey 89
- `decsys webhooks list bzb` -> list webhooks configured for Survey 1 (decoded from the friendly id for survey 1, instance 1)

