### PR TITLE
AB#173616: Cannot update a component (LocalInstancesProvider) while rendering a different component (SurveyBootstrapper).

### DIFF
--- a/app/client-app/src/app/pages/Survey.jsx
+++ b/app/client-app/src/app/pages/Survey.jsx
@@ -115,10 +115,14 @@ const SurveyBootstrapper = ({ id: urlFriendlyId }) => {
   if (!progress.participantId && !progress.newParticipantId)
     return <ParticipantIdEntry friendlyId={accessFriendlyId} />;
 
-  storeInstanceParticipantId(
-    accessFriendlyId,
-    progress.newParticipantId ?? progress.participantId
-  );
+  useEffect(() => {
+    if (progress.newParticipantId || progress.participantId) {
+      storeInstanceParticipantId(
+        accessFriendlyId,
+        progress.newParticipantId ?? progress.participantId
+      );
+    }
+  }, [accessFriendlyId, progress.newParticipantId, progress.participantId]);
 
   if (!progress.newParticipantId && progress.participantId) {
     // Valid Survey Progress


### PR DESCRIPTION
Fix this issue by calling storeInstanceParticipantId after the component has rendered, avoiding setState warning during the rendering process