### PR TITLE
AB#182085: Fix About Decys Lucid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DECSYS is a tool that enables the creation and administration of digital surveys
 
 # 📝 Documentation
 
-- [Research Project Homepage](https://www.lucidresearch.org/decsys.html)
+- [Research Project Homepage](https://www.lucidresearch.org/decsys)
 - [Usage and Technical Overview of the Application](https://decsys.github.io/decsys)
 - [Custom Response Item Guide](https://github.com/decsys/component-boilerplate/wiki)
 

--- a/app/client-app/src/app/layouts/components/DefaultAppBar.jsx
+++ b/app/client-app/src/app/layouts/components/DefaultAppBar.jsx
@@ -46,7 +46,7 @@ const HelpMenu = () => (
       </MenuItem>
       <MenuItem
         as="a"
-        href="http://www.lucidresearch.org/decsys.html"
+        href="http://www.lucidresearch.org/decsys"
         target="_blank"
       >
         <Stack direction="row" align="center" spacing={1}>

--- a/docs/config/helpers.js
+++ b/docs/config/helpers.js
@@ -154,7 +154,7 @@ const buildFooterConfig = (docsRoutePrefix) => ({
       items: [
         {
           label: "LUCID",
-          href: "https://www.lucidresearch.org/decsys.html",
+          href: "https://www.lucidresearch.org/decsys",
         },
         {
           label: "GitHub",

--- a/docs/docs/users/overview.md
+++ b/docs/docs/users/overview.md
@@ -28,6 +28,6 @@ The [Developer Guide](../devs/contributing/source-code.md) and [Technical Refere
 There are also other places you can find specific information about aspects of the wider DECSYS Project:
 
 - [Running or Building the Survey Platform](https://github.com/decsys/decsys/blob/master/README.md)
-- [About the DECSYS Project](http://www.lucidresearch.org/decsys.html)
+- [About the DECSYS Project](http://www.lucidresearch.org/decsys)
 - [Writing Response Components for the Platform](https://github.com/decsys/component-boilerplate/wiki)
 - [Using the Ratings Scales components in other projects](https://decsys.github.io/rating-scales/)


### PR DESCRIPTION
removes the `.html` from the link